### PR TITLE
Update first + avoid install timeout

### DIFF
--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Update all packages
+  package:
+    name: '*'
+    state: latest
+  async: 600
+  poll: 10
+
 - name: Make sure we have all required packages
   package:
     name: "{{ item }}"
@@ -83,13 +90,6 @@
   with_items:
    - btrfs-progs-devel
   when: ansible_distribution in ['Fedora']
-
-- name: Update all packages
-  package:
-    name: '*'
-    state: latest
-  async: 600
-  poll: 10
 
 - name: ensure directories exist as needed
   file:


### PR DESCRIPTION
**- What I did**

* Move the package-update task above the install task.
* Increase the package-install timeout to avoid failing during periods of slow throughput.

**- How I did it**

* Copy paste
* Use a jinja2 template to express the timeout (in seconds) as ``60 * 20``.

**- How to verify it**

* CI jobs will pass now, and under future slow-networking

**- Description for the changelog**

N/A