### PR TITLE
[DO NOT MERGE] Revert "container_exec: fix terminal true process json"

### DIFF
--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
@@ -53,14 +55,28 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 		return fmt.Errorf("container is not created or running")
 	}
 
-	processFile, err := oci.PrepareProcessExec(c, cmd, tty)
+	f, err := ioutil.TempFile("", "exec-process")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(processFile.Name())
+	defer os.RemoveAll(f.Name())
+
+	pspec := c.Spec().Process
+	pspec.Args = cmd
+	processJSON, err := json.Marshal(pspec)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
+		return err
+	}
 
 	args := []string{"exec"}
-	args = append(args, "--process", processFile.Name())
+	if tty {
+		args = append(args, "-t")
+	}
+	args = append(args, "-p", f.Name())
 	args = append(args, c.ID())
 	execCmd := exec.Command(ss.runtimeServer.Runtime().Path(c), args...)
 	var cmdErr error


### PR DESCRIPTION
This reverts commit afeab27a362fdf66c2438cac1476d067850b0593.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I'm reverting this just to see which e2e test fails w/o this patch. The reason is as soon as we spot the test, we need to add it upstream to the Conformance suite so we won't regress anymore on that.

Likewise, we should add the e2e test failing in #1217 to the Conformance suite upstream. Will follow up on that.

After we identify the failing test, we add it to Conformance upstream and we revert the changes in https://github.com/kubernetes-incubator/cri-o/pull/1208/files#diff-fe1da1c8c03c981d03c116369ed2728d so we're back to e2e-conformance. The full e2e will be run as a postsubmit.

@mrunalp 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
