### PR TITLE
docs: Modify the comment of --storage-driver.

### DIFF
--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -122,7 +122,7 @@ crio [GLOBAL OPTIONS] config [OPTIONS]
 
 **--signature-policy**="": Path to the signature policy json file (default: "", to use the system-wide default)
 
-**--storage-driver**: OCI storage driver (default: "devicemapper")
+**--storage-driver**: OCI storage driver (default: "overlay")
 
 **--storage-opt**: OCI storage driver option (no default)
 


### PR DESCRIPTION
**- What I did**
Currently, the default storage driver is overlayfs , so we need to modify this comment.

Signed-off-by: Chenditang chendt.fnst@cn.fujitsu.com

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
