### PR TITLE
[release-1.11] server: serve streaming on localhost on a random port

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -243,7 +243,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "stream-port",
-			Usage: "bind port for streaming socket (default: \"10010\")",
+			Usage: "bind port for streaming socket (default: \"0\")",
 		},
 		cli.StringFlag{
 			Name:  "log",

--- a/server/config.go
+++ b/server/config.go
@@ -118,8 +118,8 @@ func DefaultConfig() *Config {
 		Config: *lib.DefaultConfig(),
 		APIConfig: APIConfig{
 			Listen:        "/var/run/crio/crio.sock",
-			StreamAddress: "",
-			StreamPort:    "10010",
+			StreamAddress: "127.0.0.1",
+			StreamPort:    "0",
 		},
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -383,7 +383,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 	s.stream.streamServerCloseCh = make(chan struct{})
 	go func() {
 		defer close(s.stream.streamServerCloseCh)
-		if err := s.stream.streamServer.Start(true); err != nil {
+		if err := s.stream.streamServer.Start(true); err != nil && err != http.ErrServerClosed {
 			logrus.Errorf("Failed to start streaming server: %v", err)
 		}
 	}()

--- a/server/server.go
+++ b/server/server.go
@@ -341,7 +341,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 
 	bindAddress := net.ParseIP(config.StreamAddress)
 	if bindAddress == nil {
-		bindAddress, err = knet.ChooseBindAddress(net.IP{0, 0, 0, 0})
+		bindAddress, err = knet.ChooseBindAddress(nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
same as https://github.com/kubernetes-incubator/cri-o/pull/1714 but for `release-1.11`

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
