### PR TITLE
main: allow defining default conf file at build time

### DIFF
--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Open Container Initiative Daemon
 Documentation=https://github.com/kubernetes-sigs/cri-o
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
crio.conf file may not be present in default /etc/crio directory,
but in /usr/share/defaults/crio directory in stateless systems.
This change includes looking in /usr/share/defaults/crio if
not found in default location.

Signed-off-by: Jose Lamego <jose.a.lamego@intel.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
