### PR TITLE
contib: test: enable critest junit reports

### DIFF
--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -16,8 +16,13 @@
 - name: Add masquerade for localhost
   command: iptables -t nat -I POSTROUTING -s 127.0.0.1 ! -d 127.0.0.1 -j MASQUERADE
 
+- name: ensure directory exists for e2e reports
+  file:
+    path: "{{ artifacts }}"
+    state: directory
+
 - name: run critest validation
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock v"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
   async: 5400
@@ -30,7 +35,7 @@
   # https://bugzilla.redhat.com/show_bug.cgi?id=1414236
   # https://access.redhat.com/solutions/2897781
 - name: run critest validation
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true'"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true'"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
   async: 5400
@@ -38,7 +43,7 @@
   when: ansible_distribution in ['RedHat', 'CentOS']
 
 - name: run critest benchmarks
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
   async: 5400

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -41,10 +41,3 @@
   async: 5400
   poll: 30
   when: ansible_distribution in ['RedHat', 'CentOS']
-
-- name: run critest benchmarks
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator/cri-o"
-  async: 5400
-  poll: 30


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

enabled report-dir for critest so our instance of gubernator can display results
removed critest benchmarks as they're not needed

**- How I did it**

vim

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
