### PR TITLE
contrib: test: run e2e in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,11 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean
 
 # install bats
+ENV BATS_COMMIT v1.1.0
 RUN cd /tmp \
-    && git clone https://github.com/sstephenson/bats.git \
-    && cd bats \
-    && git reset --hard 03608115df2071fff4eaaff1605768c275e5f81f \
+    && git clone https://github.com/bats-core/bats-core.git \
+    && cd bats-core \
+    && git checkout -q "$BATS_COMMIT" \
     && ./install.sh /usr/local
 
 # install criu

--- a/contrib/test/integration/build/bats.yml
+++ b/contrib/test/integration/build/bats.yml
@@ -2,13 +2,13 @@
 
 - name: clone bats source repo
   git:
-    repo: "https://github.com/sstephenson/bats.git"
-    dest: "{{ ansible_env.GOPATH }}/src/github.com/sstephenson/bats"
+    repo: "https://github.com/bats-core/bats-core.git"
+    dest: "{{ ansible_env.GOPATH }}/src/github.com/bats-core/bats-core"
 
 - name: install bats
   command: "./install.sh /usr/local"
   args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/sstephenson/bats"
+    chdir: "{{ ansible_env.GOPATH }}/src/github.com/bats-core/bats-core"
 
 - name: link bats
   file:

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -16,8 +16,13 @@
 - name: Add masquerade for localhost
   command: iptables -t nat -I POSTROUTING -s 127.0.0.1 ! -d 127.0.0.1 -j MASQUERADE
 
+- name: ensure directory exists for e2e reports
+  file:
+    path: "{{ artifacts }}"
+    state: directory
+
 - name: run critest validation
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock v"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
   async: 5400
@@ -30,7 +35,7 @@
   # https://bugzilla.redhat.com/show_bug.cgi?id=1414236
   # https://access.redhat.com/solutions/2897781
 - name: run critest validation
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true'"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --ginkgo.skip='should not allow privilege escalation when true'"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
   async: 5400
@@ -38,7 +43,7 @@
   when: ansible_distribution in ['RedHat', 'CentOS']
 
 - name: run critest benchmarks
-  shell: "critest --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
+  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
   async: 5400

--- a/contrib/test/integration/critest.yml
+++ b/contrib/test/integration/critest.yml
@@ -41,10 +41,3 @@
   async: 5400
   poll: 30
   when: ansible_distribution in ['RedHat', 'CentOS']
-
-- name: run critest benchmarks
-  shell: "critest --report-dir={{ artifacts }} --runtime-endpoint /var/run/crio/crio.sock --image-endpoint /var/run/crio/crio.sock --benchmark"
-  args:
-    chdir: "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs/cri-o"
-  async: 5400
-  poll: 30

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -61,7 +61,7 @@
         GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config
+                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config|Pods.should.support.pod.readiness.gates
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "

--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -58,7 +58,7 @@
 - name: Buffer the e2e testing command to workaround Ansible YAML folding "feature"
   set_fact:
     e2e_shell_cmd: >
-        /usr/bin/go run hack/e2e.go
+        GINKGO_PARALLEL_NODES=6 GINKGO_PARALLEL=y /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
                         --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|for.NodePort.service|type.clusterIP|unready.pods|ExternalName.services|Guestbook.application|in-cluster.config

--- a/contrib/test/integration/golang.yml
+++ b/contrib/test/integration/golang.yml
@@ -44,7 +44,7 @@
     - "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator"
     - "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs"
     - "{{ ansible_env.GOPATH }}/src/github.com/k8s.io"
-    - "{{ ansible_env.GOPATH }}/src/github.com/sstephenson"
+    - "{{ ansible_env.GOPATH }}/src/github.com/bats-core"
     - "{{ ansible_env.GOPATH }}/src/github.com/opencontainers"
 
 - name: install Go tools and dependencies

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -97,7 +97,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.12"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s node-e2e tests
@@ -114,7 +114,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.12"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -86,7 +86,7 @@ type ImageServer interface {
 	ImageStatus(systemContext *types.SystemContext, filter string) (*ImageResult, error)
 	// PrepareImage returns an Image where the config digest can be grabbed
 	// for further analysis. Call Close() on the resulting image.
-	PrepareImage(systemContext *types.SystemContext, imageName string, options *copy.Options) (types.Image, error)
+	PrepareImage(imageName string, options *copy.Options) (types.Image, error)
 	// PullImage imports an image from the specified location.
 	PullImage(systemContext *types.SystemContext, imageName string, options *copy.Options) (types.ImageReference, error)
 	// UntagImage removes a name from the specified image, and if it was
@@ -379,16 +379,17 @@ func (svc *imageService) prepareReference(imageName string, options *copy.Option
 	return srcRef, nil
 }
 
-func (svc *imageService) PrepareImage(systemContext *types.SystemContext, imageName string, options *copy.Options) (types.Image, error) {
-	if options == nil {
-		options = &copy.Options{}
-	}
-
+func (svc *imageService) PrepareImage(imageName string, options *copy.Options) (types.Image, error) {
 	srcRef, err := svc.prepareReference(imageName, options)
 	if err != nil {
 		return nil, err
 	}
-	return srcRef.NewImage(svc.ctx, systemContext)
+
+	sourceCtx := &types.SystemContext{}
+	if options.SourceCtx != nil {
+		sourceCtx = options.SourceCtx
+	}
+	return srcRef.NewImage(svc.ctx, sourceCtx)
 }
 
 func (svc *imageService) PullImage(systemContext *types.SystemContext, imageName string, options *copy.Options) (types.ImageReference, error) {

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -87,7 +87,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 	for _, ctr := range ctrList {
 		podSandboxID := ctr.Sandbox()
 		cState := s.Runtime().ContainerStatus(ctr)
-		created := cState.Created.UnixNano()
+		created := ctr.CreatedAt().UnixNano()
 		rState := pb.ContainerState_CONTAINER_UNKNOWN
 		cID := ctr.ID()
 		img := &pb.ImageSpec{

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -67,20 +67,18 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		cState = s.Runtime().ContainerStatus(c)
 	}
 
+	created := c.CreatedAt().UnixNano()
 	switch cState.Status {
 	case oci.ContainerStateCreated:
 		rStatus = pb.ContainerState_CONTAINER_CREATED
-		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = created
 	case oci.ContainerStateRunning:
 		rStatus = pb.ContainerState_CONTAINER_RUNNING
-		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started
 	case oci.ContainerStateStopped:
 		rStatus = pb.ContainerState_CONTAINER_EXITED
-		created := cState.Created.UnixNano()
 		resp.Status.CreatedAt = created
 		started := cState.Started.UnixNano()
 		resp.Status.StartedAt = started

--- a/server/image_pull.go
+++ b/server/image_pull.go
@@ -57,6 +57,7 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 		options := &copy.Options{
 			SourceCtx: &types.SystemContext{
 				DockerRegistryUserAgent: useragent.Get(ctx),
+				SignaturePolicyPath:     s.ImageContext().SignaturePolicyPath,
 			},
 		}
 
@@ -70,13 +71,13 @@ func (s *Server) PullImage(ctx context.Context, req *pb.PullImageRequest) (resp 
 			}
 		}
 
-		tmpImg, err := s.StorageImageServer().PrepareImage(s.ImageContext(), img, options)
+		var tmpImg types.Image
+		tmpImg, err = s.StorageImageServer().PrepareImage(img, options)
 		if err != nil {
 			logrus.Debugf("error preparing image %s: %v", img, err)
 			continue
 		}
 
-		// let's be smart, docker doesn't repull if image already exists.
 		var storedImage *storage.ImageResult
 		storedImage, err = s.StorageImageServer().ImageStatus(s.ImageContext(), img)
 		if err == nil {

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -71,7 +71,6 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			continue
 		}
 		cState := s.Runtime().ContainerStatus(podInfraContainer)
-		created := cState.Created.UnixNano()
 		rStatus := pb.PodSandboxState_SANDBOX_NOTREADY
 		if cState.Status == oci.ContainerStateRunning {
 			rStatus = pb.PodSandboxState_SANDBOX_READY
@@ -79,7 +78,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 
 		pod := &pb.PodSandbox{
 			Id:          sb.ID(),
-			CreatedAt:   created,
+			CreatedAt:   podInfraContainer.CreatedAt().UnixNano(),
 			State:       rStatus,
 			Labels:      sb.Labels(),
 			Annotations: sb.Annotations(),

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -155,10 +155,7 @@ func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
 	return s.StorageRuntimeServer().SetContainerMetadata(id, storageMetadata)
 }
 
-func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (processLabel string, mountLabel string, err error) {
-	if privileged {
-		return "", "", nil
-	}
+func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string, string, error) {
 	labels := []string{}
 	if selinuxOptions != nil {
 		if selinuxOptions.User != "" {
@@ -174,7 +171,18 @@ func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (proces
 			labels = append(labels, "level:"+selinuxOptions.Level)
 		}
 	}
-	return label.InitLabels(labels)
+	var (
+		processLabel, mountLabel string
+		err                      error
+	)
+	processLabel, mountLabel, err = label.InitLabels(labels)
+	if err != nil {
+		return "", "", err
+	}
+	if privileged {
+		processLabel = ""
+	}
+	return processLabel, mountLabel, nil
 }
 
 // convertCgroupFsNameToSystemd converts an expanded cgroupfs name to its systemd name.

--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ Integration tests on the other hand are meant to test a specific feature end
 to end.
 
 Integration tests are written in *bash* using the
-[bats](https://github.com/sstephenson/bats) framework.
+[bats](https://github.com/bats-core/bats-core) framework.
 
 ## Running integration tests
 
@@ -28,11 +28,11 @@ $ make integration TESTFLAGS="runtimeversion.bats"
 ### On your host
 
 To run the integration tests on your host, you will first need to setup a development environment plus
-[bats](https://github.com/sstephenson/bats#installing-bats-from-source)
+[bats](https://github.com/bats-core/bats-core#installing-bats-from-source)
 For example:
 ```
 $ cd ~/go/src/github.com
-$ git clone https://github.com/sstephenson/bats.git
+$ git clone https://github.com/bats-core/bats-core.git
 $ cd bats
 $ ./install.sh /usr/local
 ```

--- a/vendor/github.com/containers/libpod/README.md
+++ b/vendor/github.com/containers/libpod/README.md
@@ -20,7 +20,7 @@ At a high level, the scope of libpod and podman is the following:
 ## What is not in scope for this project?
 
 * Signing and pushing images to various image storages. See [Skopeo](https://github.com/projectatomic/skopeo/).
-* Container Runtimes daemons for working with Kubernetes CRIs. See [CRI-O](https://github.com/kubernetes-sigs/cri-o). We are working to integrate libpod into CRI-O to share containers and backend code with Podman.
+* Container Runtimes daemons for working with Kubernetes CRIs. See [CRI-O](https://github.com/kubernetes-incubator/cri-o). We are working to integrate libpod into CRI-O to share containers and backend code with Podman.
 
 ## OCI Projects Plans
 
@@ -30,7 +30,7 @@ The plan is to use OCI projects and best of breed libraries for different aspect
 - Storage: Container and image storage is managed by [containers/storage](https://github.com/containers/storage)
 - Networking: Networking support through use of [CNI](https://github.com/containernetworking/cni)
 - Builds: Builds are supported via [Buildah](https://github.com/projectatomic/buildah).
-- Conmon: [Conmon](https://github.com/kubernetes-sigs/cri-o) is a tool for monitoring OCI runtimes. It is part of the CRI-O package
+- Conmon: [Conmon](https://github.com/kubernetes-incubator/cri-o) is a tool for monitoring OCI runtimes. It is part of the CRI-O package
 
 ## Podman Information for Developers
 

--- a/vendor/github.com/containers/libpod/pkg/hooks/0.1.0/hook.go
+++ b/vendor/github.com/containers/libpod/pkg/hooks/0.1.0/hook.go
@@ -19,7 +19,7 @@ type Hook struct {
 	Hook      *string  `json:"hook"`
 	Arguments []string `json:"arguments,omitempty"`
 
-	// https://github.com/kubernetes-sigs/cri-o/pull/1235
+	// https://github.com/kubernetes-incubator/cri-o/pull/1235
 	Stages []string `json:"stages"`
 	Stage  []string `json:"stage"`
 


### PR DESCRIPTION
we don't run any serial test so it's ok to move to parallel to speed up
test time. You can check no serial in
https://openshift-gce-devel.appspot.com/build/origin-federated-results/pr-logs/pull/kubernetes-incubator_cri-o/1715/test_pull_request_crio_e2e_fedora/1171/

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-incubator/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
