### PR TITLE
contrib: test: use release-* branches, not master

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -97,7 +97,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.12"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s node-e2e tests
@@ -114,7 +114,7 @@
       include: "build/kubernetes.yml"
       vars:
           force_clone: True
-          k8s_git_version: "master"
+          k8s_git_version: "release-1.12"
           k8s_github_fork: "kubernetes"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

Let's see if this branch is ok, we'll take care of `master` later (which is going to have ~390 tests, instead of ~352 of now)

This was why our e2e broke: https://github.com/kubernetes/kubernetes/pull/67571 and we're timing out