### PR TITLE
server: don't wipe out the selinux mount label if privileged

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -155,10 +155,7 @@ func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
 	return s.StorageRuntimeServer().SetContainerMetadata(id, storageMetadata)
 }
 
-func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (processLabel string, mountLabel string, err error) {
-	if privileged {
-		return "", "", nil
-	}
+func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string, string, error) {
 	labels := []string{}
 	if selinuxOptions != nil {
 		if selinuxOptions.User != "" {
@@ -174,7 +171,18 @@ func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (proces
 			labels = append(labels, "level:"+selinuxOptions.Level)
 		}
 	}
-	return label.InitLabels(labels)
+	var (
+		processLabel, mountLabel string
+		err                      error
+	)
+	processLabel, mountLabel, err = label.InitLabels(labels)
+	if err != nil {
+		return "", "", err
+	}
+	if privileged {
+		processLabel = ""
+	}
+	return processLabel, mountLabel, nil
 }
 
 // convertCgroupFsNameToSystemd converts an expanded cgroupfs name to its systemd name.


### PR DESCRIPTION
When running a pod with privileged we just need to set the process
label to the empty string. We don't need to wipe out the mount labels
as those are stil applied to mounts and rootfs even if in privileged
mode.

Fix https://bugzilla.redhat.com/show_bug.cgi?id=1624326

We need this to also match the behavior with docker:

```
docker run -ti -v $(mktemp -d):/testselinux:Z --security-opt label=level:s0:c25,c968 fedora ls -ldZ /testselinux
drwx------. 2 27212 27212 system_u:object_r:container_file_t:s0:c25,c968 40 Sep  6 17:13 /testselinux

docker run --privileged -ti -v $(mktemp -d):/testselinux:Z --security-opt label=level:s0:c25,c968 fedora ls -ldZ /testselinux
drwx------. 2 27212 27212 system_u:object_r:container_file_t:s0:c25,c968 40 Sep  6 17:14 /testselinux
```

You can see the mount label is still getting applied to privileged
containers.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>