### PR TITLE
test: Add directory for kubernetes-sigs

### DIFF
--- a/contrib/test/integration/golang.yml
+++ b/contrib/test/integration/golang.yml
@@ -42,6 +42,7 @@
   with_items:
     - "{{ ansible_env.GOPATH }}/src/github.com/containernetworking"
     - "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-incubator"
+    - "{{ ansible_env.GOPATH }}/src/github.com/kubernetes-sigs"
     - "{{ ansible_env.GOPATH }}/src/github.com/k8s.io"
     - "{{ ansible_env.GOPATH }}/src/github.com/sstephenson"
     - "{{ ansible_env.GOPATH }}/src/github.com/opencontainers"


### PR DESCRIPTION
We need to keep the old directory for the other branches in the base image.
@runcom  PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

