### PR TITLE
RFC: config: CNI: multiple plugin binary directories

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -305,8 +305,9 @@ image_volumes = "{{ .ImageVolumes }}"
 # Path to the directory where CNI configuration files are located.
 network_dir = "{{ .NetworkDir }}"
 
-# Path to directory where CNI plugin binaries are located.
-plugin_dir = "{{ .PluginDir }}"
+# Paths to directories where CNI plugin binaries are located.
+plugin_dir = [
+{{ range $opt := .PluginDir }}{{ printf "\t%q,\n" $opt }}{{ end }}]
 `))
 
 // TODO: Currently ImageDir isn't really used, so we haven't added it to this

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -171,7 +171,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		config.NetworkDir = ctx.GlobalString("cni-config-dir")
 	}
 	if ctx.GlobalIsSet("cni-plugin-dir") {
-		config.PluginDir = ctx.GlobalString("cni-plugin-dir")
+		config.PluginDir = ctx.GlobalStringSlice("cni-plugin-dir")
 	}
 	if ctx.GlobalIsSet("image-volumes") {
 		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))
@@ -389,7 +389,7 @@ func main() {
 			Name:  "cni-config-dir",
 			Usage: "CNI configuration files directory",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:  "cni-plugin-dir",
 			Usage: "CNI plugin binaries directory",
 		},

--- a/contrib/cni/README.md
+++ b/contrib/cni/README.md
@@ -9,7 +9,7 @@ To use these configurations, place them in `/etc/cni/net.d` (or the directory
 specified by `crio.network.network_dir` in your `crio.conf`).
 
 In addition, you need to install the [CNI plugins][cni] necessary into
-`/opt/cni/bin` (or the directory specified by `crio.network.plugin_dir`). The
+`/opt/cni/bin` (or the directories specified by `crio.network.plugin_dir`). The
 two plugins necessary for the example CNI configurations are `loopback` and
 `bridge`.
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -229,8 +229,8 @@ The `crio.network` table containers settings pertaining to the management of CNI
 **network_dir**="/etc/cni/net.d/"
   Path to the directory where CNI configuration files are located.
 
-**plugin_dir**="/opt/cni/bin/"
-  Path to directory where CNI plugin binaries are located.
+**plugin_dir**=["/opt/cni/bin/",]
+  List of paths to directories where CNI plugin binaries are located.
 
 # SEE ALSO
 containers-storage.conf(5), containers-policy.json(5), containers-registries.conf(5), crio(8)

--- a/lib/config.go
+++ b/lib/config.go
@@ -298,7 +298,7 @@ type NetworkConfig struct {
 	NetworkDir string `toml:"network_dir"`
 
 	// PluginDir is where CNI plugin binaries are stored.
-	PluginDir string `toml:"plugin_dir"`
+	PluginDir []string `toml:"plugin_dir"`
 }
 
 // tomlConfig is another way of looking at a Config, which is
@@ -417,7 +417,7 @@ func DefaultConfig() *Config {
 		},
 		NetworkConfig: NetworkConfig{
 			NetworkDir: cniConfigDir,
-			PluginDir:  cniBinDir,
+			PluginDir:  []string{cniBinDir},
 		},
 	}
 }

--- a/lib/testdata/config.toml
+++ b/lib/testdata/config.toml
@@ -24,4 +24,4 @@
     image_volumes = "mkdir"
   [crio.network]
     network_dir = "/etc/cni/net.d/"
-    plugin_dir = "/opt/cni/bin/"
+    plugin_dir = ["/opt/cni/bin/"]

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -57,7 +57,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.ImageConfig.Registries[0], "registry:4321"},
 
 		{c.NetworkConfig.NetworkDir, "/etc/cni/net.d/"},
-		{c.NetworkConfig.PluginDir, "/opt/cni/bin/"},
+		{c.NetworkConfig.PluginDir[0], "/opt/cni/bin/"},
 	}
 	for _, tc := range testCases {
 		if tc.fieldValue != tc.expected {

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -38,4 +38,4 @@ registries = [
 
 [crio.network]
 network_dir = "/etc/cni/net.d/"
-plugin_dir = "/opt/cni/bin/"
+plugin_dir = ["/opt/cni/bin/"]

--- a/server/server.go
+++ b/server/server.go
@@ -301,7 +301,7 @@ func New(ctx context.Context, config *Config) (*Server, error) {
 		return nil, err
 	}
 
-	netPlugin, err := ocicni.InitCNI(config.NetworkDir, config.PluginDir)
+	netPlugin, err := ocicni.InitCNI("", config.NetworkDir, config.PluginDir...)
 	if err != nil {
 		return nil, err
 	}

--- a/server/utils.go
+++ b/server/utils.go
@@ -102,6 +102,7 @@ func newPodNetwork(sb *sandbox.Sandbox) ocicni.PodNetwork {
 	return ocicni.PodNetwork{
 		Name:      sb.KubeName(),
 		Namespace: sb.Namespace(),
+		Networks:  make([]string, 0),
 		ID:        sb.ID(),
 		NetNS:     sb.NetNsPath(),
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/containers/image 93bced01015eb94bec4821df1876314be8197680
 github.com/docker/docker-credential-helpers d68f9aeca33f5fd3f08eeae5e9d175edf4e731d1
 github.com/ostreedev/ostree-go master
 github.com/containers/storage v1.11
-github.com/containernetworking/cni v0.4.0
+github.com/containernetworking/cni v0.7.0-alpha1
 google.golang.org/grpc 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e https://github.com/grpc/grpc-go
 google.golang.org/genproto 09f6ed296fc66555a25fe4ce95173148778dfa85
 github.com/opencontainers/selinux 6ba084dd09db3dfe49a839bab0bbe97fd9274d80
@@ -125,7 +125,7 @@ github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
 github.com/cyphar/filepath-securejoin v0.2.1
 gopkg.in/square/go-jose.v2 89060dee6a84df9a4dae49f676f0c755037834f1
 golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
-github.com/cri-o/ocicni 84aa158d2bacf95147b2b0a89615dd665630f440
+github.com/cri-o/ocicni v0.1.0
 github.com/containers/libpod e75469ab99c48e9fbe2b36ade229d384bdea9144
 github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/modern-go/reflect2 05fbef0ca5da472bbf96c9322b84a53edc03c9fd

--- a/vendor/github.com/containernetworking/cni/README.md
+++ b/vendor/github.com/containernetworking/cni/README.md
@@ -1,16 +1,29 @@
-[![Build Status](https://travis-ci.org/containernetworking/cni.svg?branch=master)](https://travis-ci.org/containernetworking/cni)
+[![Linux Build Status](https://travis-ci.org/containernetworking/cni.svg?branch=master)](https://travis-ci.org/containernetworking/cni)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/wtrkou8oow7x533e/branch/master?svg=true)](https://ci.appveyor.com/project/cni-bot/cni/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/containernetworking/cni/badge.svg?branch=master)](https://coveralls.io/github/containernetworking/cni?branch=master)
 [![Slack Status](https://cryptic-tundra-43194.herokuapp.com/badge.svg)](https://cryptic-tundra-43194.herokuapp.com/)
+
+![CNI Logo](logo.png)
+
+---
+
+# Community Sync Meeting
+
+There is a community sync meeting for users and developers every 1-2 months. The next meeting will help on a Google Hangout and the link is in the [agenda](https://docs.google.com/document/d/10ECyT2mBGewsJUcmYmS8QNo1AcNgy2ZIe2xS7lShYhE/edit?usp=sharing) (Notes from previous meeting are also in this doc). 
+
+The next meeting will be held on *Wednesday, October 4th* at *3:00pm UTC / 11:00am EDT / 8:00am PDT* [Add to Calendar](https://www.worldtimebuddy.com/?qm=1&lid=100,5,2643743,5391959&h=100&date=2017-10-04&sln=15-16).
+
+---
 
 # CNI - the Container Network Interface
 
 ## What is CNI?
 
-The CNI (_Container Network Interface_) project consists of a specification and libraries for writing plugins to configure network interfaces in Linux containers, along with a number of supported plugins.
+CNI (_Container Network Interface_), a [Cloud Native Computing Foundation](https://cncf.io) project, consists of a specification and libraries for writing plugins to configure network interfaces in Linux containers, along with a number of supported plugins.
 CNI concerns itself only with network connectivity of containers and removing allocated resources when the container is deleted.
 Because of this focus, CNI has a wide range of support and the specification is simple to implement.
 
-As well as the [specification](SPEC.md), this repository contains the Go source code of a library for integrating CNI into applications, an example command-line tool, a template for making new plugins, and the supported plugins.
+As well as the [specification](SPEC.md), this repository contains the Go source code of a [library for integrating CNI into applications](libcni) and an [example command-line tool](cnitool) for executing CNI plugins.  A [separate repository contains reference plugins](https://github.com/containernetworking/plugins) and a template for making new plugins.
 
 The template code makes it straight-forward to create a CNI plugin for an existing container networking project.
 CNI also makes a good framework for creating a new container networking project from scratch.
@@ -25,10 +38,11 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 ## Who is using CNI?
 ### Container runtimes
 - [rkt - container engine](https://coreos.com/blog/rkt-cni-networking.html)
-- [Kurma - container runtime](http://kurma.io/)
 - [Kubernetes - a system to simplify container operations](http://kubernetes.io/docs/admin/network-plugins/)
-- [Cloud Foundry - a platform for cloud applications](https://github.com/cloudfoundry-incubator/netman-release)
-- [Mesos - a distributed systems kernel](https://github.com/apache/mesos/blob/master/docs/cni.md)
+- [OpenShift - Kubernetes with additional enterprise features](https://github.com/openshift/origin/blob/master/docs/openshift_networking_requirements.md)
+- [Cloud Foundry - a platform for cloud applications](https://github.com/cloudfoundry-incubator/cf-networking-release)
+- [Apache Mesos - a distributed systems kernel](https://github.com/apache/mesos/blob/master/docs/cni.md)
+- [Amazon ECS - a highly scalable, high performance container management service](https://aws.amazon.com/ecs/)
 
 ### 3rd party plugins
 - [Project Calico - a layer 3 virtual network](https://github.com/projectcalico/calico-cni)
@@ -37,8 +51,18 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [SR-IOV](https://github.com/hustcat/sriov-cni)
 - [Cilium - BPF & XDP for containers](https://github.com/cilium/cilium)
 - [Infoblox - enterprise IP address management for containers](https://github.com/infobloxopen/cni-infoblox)
+- [Multus - a Multi plugin](https://github.com/Intel-Corp/multus-cni)
+- [Romana - Layer 3 CNI plugin supporting network policy for Kubernetes](https://github.com/romana/kube)
+- [CNI-Genie - generic CNI network plugin](https://github.com/Huawei-PaaS/CNI-Genie)
+- [Nuage CNI - Nuage Networks SDN plugin for network policy kubernetes support ](https://github.com/nuagenetworks/nuage-cni)
+- [Silk - a CNI plugin designed for Cloud Foundry](https://github.com/cloudfoundry-incubator/silk)
+- [Linen - a CNI plugin designed for overlay networks with Open vSwitch and fit in SDN/OpenFlow network environment](https://github.com/John-Lin/linen-cni)
+- [Vhostuser - a Dataplane network plugin - Supports OVS-DPDK & VPP](https://github.com/intel/vhost-user-net-plugin)
+- [Amazon ECS CNI Plugins - a collection of CNI Plugins to configure containers with Amazon EC2 elastic network interfaces (ENIs)](https://github.com/aws/amazon-ecs-cni-plugins)
+- [Bonding CNI - a Link aggregating plugin to address failover and high availability network](https://github.com/Intel-Corp/bond-cni)
+- [ovn-kubernetes - an container network plugin built on Open vSwitch (OVS) and Open Virtual Networking (OVN) with support for both Linux and Windows](https://github.com/openvswitch/ovn-kubernetes)
 
-The CNI team also maintains some [core plugins](plugins).
+The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 
 
 ## Contributing to CNI
@@ -50,19 +74,16 @@ If you intend to contribute to code or documentation, please read [CONTRIBUTING.
 
 ### Requirements
 
-CNI requires Go 1.5+ to build.
+The CNI spec is language agnostic.  To use the Go language libraries in this repository, you'll need a recent version of Go.  Our [automated tests](https://travis-ci.org/containernetworking/cni/builds) cover Go versions 1.7 and 1.8.
 
-Go 1.5 users will need to set GO15VENDOREXPERIMENT=1 to get vendored
-dependencies. This flag is set by default in 1.6.
+### Reference Plugins
 
-### Included Plugins
-
-This repository includes a number of common plugins in the `plugins/` directory.
-Please see the [Documentation/](Documentation/) directory for documentation about particular plugins.
+The CNI project maintains a set of [reference plugins](https://github.com/containernetworking/plugins) that implement the CNI specification.
+NOTE: the reference plugins used to live in this repository but have been split out into a [separate repository](https://github.com/containernetworking/plugins) as of May 2017.
 
 ### Running the plugins
 
-The scripts/ directory contains two scripts, `priv-net-run.sh` and `docker-run.sh`, that can be used to exercise the plugins.
+After building and installing the [reference plugins](https://github.com/containernetworking/plugins), you can use the `priv-net-run.sh` and `docker-run.sh` scripts in the `scripts/` directory to exercise the plugins.
 
 **note - priv-net-run.sh depends on `jq`**
 
@@ -100,14 +121,15 @@ The directory `/etc/cni/net.d` is the default location in which the scripts will
 Next, build the plugins:
 
 ```bash
-$ ./build
+$ cd $GOPATH/src/github.com/containernetworking/plugins
+$ ./build.sh
 ```
 
 Finally, execute a command (`ifconfig` in this example) in a private network namespace that has joined the `mynet` network:
 
 ```bash
-$ CNI_PATH=`pwd`/bin
-$ cd scripts
+$ CNI_PATH=$GOPATH/src/github.com/containernetworking/plugins/bin
+$ cd $GOPATH/src/github.com/containernetworking/cni/scripts
 $ sudo CNI_PATH=$CNI_PATH ./priv-net-run.sh ifconfig
 eth0      Link encap:Ethernet  HWaddr f2:c2:6f:54:b8:2b  
           inet addr:10.22.0.2  Bcast:0.0.0.0  Mask:255.255.0.0
@@ -115,7 +137,7 @@ eth0      Link encap:Ethernet  HWaddr f2:c2:6f:54:b8:2b
           UP BROADCAST MULTICAST  MTU:1500  Metric:1
           RX packets:1 errors:0 dropped:0 overruns:0 frame:0
           TX packets:0 errors:0 dropped:1 overruns:0 carrier:0
-          collisions:0 txqueuelen:0 
+          collisions:0 txqueuelen:0
           RX bytes:90 (90.0 B)  TX bytes:0 (0.0 B)
 
 lo        Link encap:Local Loopback  
@@ -124,7 +146,7 @@ lo        Link encap:Local Loopback
           UP LOOPBACK RUNNING  MTU:65536  Metric:1
           RX packets:0 errors:0 dropped:0 overruns:0 frame:0
           TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
-          collisions:0 txqueuelen:0 
+          collisions:0 txqueuelen:0
           RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
 ```
 
@@ -136,8 +158,8 @@ Use the instructions in the previous section to define a netconf and build the p
 Next, docker-run.sh script wraps `docker run`, to execute the plugins prior to entering the container:
 
 ```bash
-$ CNI_PATH=`pwd`/bin
-$ cd scripts
+$ CNI_PATH=$GOPATH/src/github.com/containernetworking/plugins/bin
+$ cd $GOPATH/src/github.com/containernetworking/cni/scripts
 $ sudo CNI_PATH=$CNI_PATH ./docker-run.sh --rm busybox:latest ifconfig
 eth0      Link encap:Ethernet  HWaddr fa:60:70:aa:07:d1  
           inet addr:10.22.0.2  Bcast:0.0.0.0  Mask:255.255.0.0
@@ -145,7 +167,7 @@ eth0      Link encap:Ethernet  HWaddr fa:60:70:aa:07:d1
           UP BROADCAST MULTICAST  MTU:1500  Metric:1
           RX packets:1 errors:0 dropped:0 overruns:0 frame:0
           TX packets:0 errors:0 dropped:1 overruns:0 carrier:0
-          collisions:0 txqueuelen:0 
+          collisions:0 txqueuelen:0
           RX bytes:90 (90.0 B)  TX bytes:0 (0.0 B)
 
 lo        Link encap:Local Loopback  
@@ -154,7 +176,7 @@ lo        Link encap:Local Loopback
           UP LOOPBACK RUNNING  MTU:65536  Metric:1
           RX packets:0 errors:0 dropped:0 overruns:0 frame:0
           TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
-          collisions:0 txqueuelen:0 
+          collisions:0 txqueuelen:0
           RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
 ```
 

--- a/vendor/github.com/containernetworking/cni/libcni/conf.go
+++ b/vendor/github.com/containernetworking/cni/libcni/conf.go
@@ -45,6 +45,9 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
 		return nil, fmt.Errorf("error parsing configuration: %s", err)
 	}
+	if conf.Network.Type == "" {
+		return nil, fmt.Errorf("error parsing configuration: missing 'type'")
+	}
 	return conf, nil
 }
 

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
@@ -22,32 +22,54 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-func DelegateAdd(delegatePlugin string, netconf []byte) (types.Result, error) {
-	if os.Getenv("CNI_COMMAND") != "ADD" {
-		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
+func delegateAddOrGet(command, delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
 	}
 
 	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
-
-	pluginPath, err := FindInPath(delegatePlugin, paths)
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
 	if err != nil {
 		return nil, err
 	}
 
-	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv())
+	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv(), exec)
 }
 
-func DelegateDel(delegatePlugin string, netconf []byte) error {
+// DelegateAdd calls the given delegate plugin with the CNI ADD action and
+// JSON configuration
+func DelegateAdd(delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	if os.Getenv("CNI_COMMAND") != "ADD" {
+		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
+	}
+	return delegateAddOrGet("ADD", delegatePlugin, netconf, exec)
+}
+
+// DelegateGet calls the given delegate plugin with the CNI GET action and
+// JSON configuration
+func DelegateGet(delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	if os.Getenv("CNI_COMMAND") != "GET" {
+		return nil, fmt.Errorf("CNI_COMMAND is not GET")
+	}
+	return delegateAddOrGet("GET", delegatePlugin, netconf, exec)
+}
+
+// DelegateDel calls the given delegate plugin with the CNI DEL action and
+// JSON configuration
+func DelegateDel(delegatePlugin string, netconf []byte, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+
 	if os.Getenv("CNI_COMMAND") != "DEL" {
 		return fmt.Errorf("CNI_COMMAND is not DEL")
 	}
 
 	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
-
-	pluginPath, err := FindInPath(delegatePlugin, paths)
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
 	if err != nil {
 		return err
 	}
 
-	return ExecPluginWithoutResult(pluginPath, netconf, ArgsFromEnv())
+	return ExecPluginWithoutResult(pluginPath, netconf, ArgsFromEnv(), exec)
 }

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
@@ -22,34 +22,62 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
-func ExecPluginWithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
-	return defaultPluginExec.WithResult(pluginPath, netconf, args)
+// Exec is an interface encapsulates all operations that deal with finding
+// and executing a CNI plugin. Tests may provide a fake implementation
+// to avoid writing fake plugins to temporary directories during the test.
+type Exec interface {
+	ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+	FindInPath(plugin string, paths []string) (string, error)
+	Decode(jsonBytes []byte) (version.PluginInfo, error)
 }
 
-func ExecPluginWithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
-	return defaultPluginExec.WithoutResult(pluginPath, netconf, args)
-}
+// For example, a testcase could pass an instance of the following fakeExec
+// object to ExecPluginWithResult() to verify the incoming stdin and environment
+// and provide a tailored response:
+//
+//import (
+//	"encoding/json"
+//	"path"
+//	"strings"
+//)
+//
+//type fakeExec struct {
+//	version.PluginDecoder
+//}
+//
+//func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+//	net := &types.NetConf{}
+//	err := json.Unmarshal(stdinData, net)
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to unmarshal configuration: %v", err)
+//	}
+//	pluginName := path.Base(pluginPath)
+//	if pluginName != net.Type {
+//		return nil, fmt.Errorf("plugin name %q did not match config type %q", pluginName, net.Type)
+//	}
+//	for _, e := range environ {
+//		// Check environment for forced failure request
+//		parts := strings.Split(e, "=")
+//		if len(parts) > 0 && parts[0] == "FAIL" {
+//			return nil, fmt.Errorf("failed to execute plugin %s", pluginName)
+//		}
+//	}
+//	return []byte("{\"CNIVersion\":\"0.4.0\"}"), nil
+//}
+//
+//func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+//	if len(paths) > 0 {
+//		return path.Join(paths[0], plugin), nil
+//	}
+//	return "", fmt.Errorf("failed to find plugin %s in paths %v", plugin, paths)
+//}
 
-func GetVersionInfo(pluginPath string) (version.PluginInfo, error) {
-	return defaultPluginExec.GetVersionInfo(pluginPath)
-}
-
-var defaultPluginExec = &PluginExec{
-	RawExec:        &RawExec{Stderr: os.Stderr},
-	VersionDecoder: &version.PluginDecoder{},
-}
-
-type PluginExec struct {
-	RawExec interface {
-		ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+func ExecPluginWithResult(pluginPath string, netconf []byte, args CNIArgs, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
 	}
-	VersionDecoder interface {
-		Decode(jsonBytes []byte) (version.PluginInfo, error)
-	}
-}
 
-func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
-	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
+	stdoutBytes, err := exec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +92,11 @@ func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs)
 	return version.NewResult(confVersion, stdoutBytes)
 }
 
-func (e *PluginExec) WithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
-	_, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
+func ExecPluginWithoutResult(pluginPath string, netconf []byte, args CNIArgs, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+	_, err := exec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	return err
 }
 
@@ -73,7 +104,10 @@ func (e *PluginExec) WithoutResult(pluginPath string, netconf []byte, args CNIAr
 // For recent-enough plugins, it uses the information returned by the VERSION
 // command.  For older plugins which do not recognize that command, it reports
 // version 0.1.0
-func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, error) {
+func GetVersionInfo(pluginPath string, exec Exec) (version.PluginInfo, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
 	args := &Args{
 		Command: "VERSION",
 
@@ -83,7 +117,7 @@ func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, erro
 		Path:   "dummy",
 	}
 	stdin := []byte(fmt.Sprintf(`{"cniVersion":%q}`, version.Current()))
-	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, stdin, args.AsEnv())
+	stdoutBytes, err := exec.ExecPlugin(pluginPath, stdin, args.AsEnv())
 	if err != nil {
 		if err.Error() == "unknown CNI_COMMAND: VERSION" {
 			return version.PluginSupports("0.1.0"), nil
@@ -91,5 +125,19 @@ func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, erro
 		return nil, err
 	}
 
-	return e.VersionDecoder.Decode(stdoutBytes)
+	return exec.Decode(stdoutBytes)
+}
+
+// DefaultExec is an object that implements the Exec interface which looks
+// for and executes plugins from disk.
+type DefaultExec struct {
+	*RawExec
+	version.PluginDecoder
+}
+
+// DefaultExec implements the Exec interface
+var _ Exec = &DefaultExec{}
+
+var defaultExec = &DefaultExec{
+	RawExec: &RawExec{Stderr: os.Stderr},
 }

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
@@ -57,3 +57,7 @@ func pluginErr(err error, output []byte) error {
 
 	return err
 }
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	return FindInPath(plugin, paths)
+}

--- a/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/current/types.go
@@ -24,9 +24,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types/020"
 )
 
-const ImplementedSpecVersion string = "0.3.1"
+const ImplementedSpecVersion string = "0.4.0"
 
-var SupportedVersions = []string{"0.3.0", ImplementedSpecVersion}
+var SupportedVersions = []string{"0.3.0", "0.3.1", ImplementedSpecVersion}
 
 func NewResult(data []byte) (types.Result, error) {
 	result := &Result{}
@@ -196,7 +196,7 @@ func (r *Result) Version() string {
 
 func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	switch version {
-	case "0.3.0", ImplementedSpecVersion:
+	case "0.3.0", "0.3.1", ImplementedSpecVersion:
 		r.CNIVersion = version
 		return r, nil
 	case types020.SupportedVersions[0], types020.SupportedVersions[1], types020.SupportedVersions[2]:

--- a/vendor/github.com/containernetworking/cni/pkg/types/types.go
+++ b/vendor/github.com/containernetworking/cni/pkg/types/types.go
@@ -63,10 +63,12 @@ type NetConf struct {
 	Name         string          `json:"name,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Capabilities map[string]bool `json:"capabilities,omitempty"`
-	IPAM         struct {
-		Type string `json:"type,omitempty"`
-	} `json:"ipam,omitempty"`
-	DNS DNS `json:"dns"`
+	IPAM         IPAM            `json:"ipam,omitempty"`
+	DNS          DNS             `json:"dns"`
+}
+
+type IPAM struct {
+	Type string `json:"type,omitempty"`
 }
 
 // NetConfList describes an ordered list of networks.
@@ -167,7 +169,7 @@ func (r *Route) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (r *Route) MarshalJSON() ([]byte, error) {
+func (r Route) MarshalJSON() ([]byte, error) {
 	rt := route{
 		Dst: IPNet(r.Dst),
 		GW:  r.GW,

--- a/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
+++ b/vendor/github.com/containernetworking/cni/pkg/version/plugin.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 )
 
 // PluginInfo reports information about CNI versioning
@@ -78,4 +80,61 @@ func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 		return nil, fmt.Errorf("decoding version info: missing field supportedVersions")
 	}
 	return &info, nil
+}
+
+// ParseVersion parses a version string like "3.0.1" or "0.4.5" into major,
+// minor, and micro numbers or returns an error
+func ParseVersion(version string) (int, int, int, error) {
+	var major, minor, micro int
+	parts := strings.Split(version, ".")
+	if len(parts) == 0 || len(parts) >= 4 {
+		return -1, -1, -1, fmt.Errorf("invalid version %q: too many or too few parts", version)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return -1, -1, -1, fmt.Errorf("failed to convert major version part %q: %v", parts[0], err)
+	}
+
+	if len(parts) >= 2 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return -1, -1, -1, fmt.Errorf("failed to convert minor version part %q: %v", parts[1], err)
+		}
+	}
+
+	if len(parts) >= 3 {
+		micro, err = strconv.Atoi(parts[2])
+		if err != nil {
+			return -1, -1, -1, fmt.Errorf("failed to convert micro version part %q: %v", parts[2], err)
+		}
+	}
+
+	return major, minor, micro, nil
+}
+
+// GreaterThanOrEqualTo takes two string versions, parses them into major/minor/micro
+// nubmers, and compares them to determine whether the first version is greater
+// than or equal to the second
+func GreaterThanOrEqualTo(version, otherVersion string) (bool, error) {
+	firstMajor, firstMinor, firstMicro, err := ParseVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	secondMajor, secondMinor, secondMicro, err := ParseVersion(otherVersion)
+	if err != nil {
+		return false, err
+	}
+
+	if firstMajor > secondMajor {
+		return true, nil
+	} else if firstMajor == secondMajor {
+		if firstMinor > secondMinor {
+			return true, nil
+		} else if firstMinor == secondMinor && firstMicro >= secondMicro {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/vendor/github.com/containernetworking/cni/pkg/version/version.go
+++ b/vendor/github.com/containernetworking/cni/pkg/version/version.go
@@ -24,7 +24,7 @@ import (
 
 // Current reports the version of the CNI spec implemented by this library
 func Current() string {
-	return "0.3.1"
+	return "0.4.0"
 }
 
 // Legacy PluginInfo describes a plugin that is backwards compatible with the
@@ -35,7 +35,7 @@ func Current() string {
 // Any future CNI spec versions which meet this definition should be added to
 // this list.
 var Legacy = PluginSupports("0.1.0", "0.2.0")
-var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1")
+var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0")
 
 var resultFactories = []struct {
 	supportedVersions []string

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/ocicni.go
@@ -4,12 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/containernetworking/cni/libcni"
+	cniinvoke "github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 )
@@ -18,14 +22,16 @@ type cniNetworkPlugin struct {
 	loNetwork *cniNetwork
 
 	sync.RWMutex
-	defaultNetwork *cniNetwork
+	defaultNetName string
+	networks       map[string]*cniNetwork
 
-	nsManager          *nsManager
-	pluginDir          string
-	cniDirs            []string
-	vendorCNIDirPrefix string
+	nsManager *nsManager
+	confDir   string
+	binDirs   []string
 
-	monitorNetDirChan chan struct{}
+	shutdownChan chan struct{}
+	watcher      *fsnotify.Watcher
+	done         *sync.WaitGroup
 
 	// The pod map provides synchronization for a given pod's network
 	// operations.  Each pod's setup/teardown/status operations
@@ -33,12 +39,17 @@ type cniNetworkPlugin struct {
 	// pods can proceed in parallel.
 	podsLock sync.Mutex
 	pods     map[string]*podLock
+
+	// For testcases
+	exec     cniinvoke.Exec
+	cacheDir string
 }
 
 type cniNetwork struct {
 	name          string
+	filePath      string
 	NetworkConfig *libcni.NetworkConfigList
-	CNIConfig     libcni.CNI
+	CNIConfig     *libcni.CNIConfig
 }
 
 var errMissingDefaultNetwork = errors.New("Missing CNI default network")
@@ -98,75 +109,111 @@ func (plugin *cniNetworkPlugin) podUnlock(podNetwork PodNetwork) {
 	}
 }
 
-func (plugin *cniNetworkPlugin) monitorNetDir() {
+func newWatcher(confDir string) (*fsnotify.Watcher, error) {
+	// Ensure plugin directory exists, because the following monitoring logic
+	// relies on that.
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create %q: %v", confDir, err)
+	}
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		logrus.Errorf("could not create new watcher %v", err)
-		return
+		return nil, fmt.Errorf("could not create new watcher %v", err)
 	}
-	defer watcher.Close()
-
-	if err = watcher.Add(plugin.pluginDir); err != nil {
-		logrus.Errorf("Failed to add watch on %q: %v", plugin.pluginDir, err)
-		return
-	}
-
-	// Now that `watcher` is running and watching the `pluginDir`
-	// gather the initial configuration, before starting the
-	// goroutine which will actually process events. It has to be
-	// done in this order to avoid missing any updates which might
-	// otherwise occur between gathering the initial configuration
-	// and starting the watcher.
-	if err := plugin.syncNetworkConfig(); err != nil {
-		logrus.Infof("Initial CNI setting failed, continue monitoring: %v", err)
-	} else {
-		logrus.Infof("Initial CNI setting succeeded")
-	}
-
-	go func() {
-		for {
-			select {
-			case event := <-watcher.Events:
-				logrus.Debugf("CNI monitoring event %v", event)
-				if event.Op&fsnotify.Create != fsnotify.Create &&
-					event.Op&fsnotify.Write != fsnotify.Write {
-					continue
-				}
-
-				if err = plugin.syncNetworkConfig(); err == nil {
-					logrus.Infof("CNI asynchronous setting succeeded")
-					continue
-				}
-
-				logrus.Errorf("CNI setting failed, continue monitoring: %v", err)
-
-			case err := <-watcher.Errors:
-				if err == nil {
-					continue
-				}
-				logrus.Errorf("CNI monitoring error %v", err)
-				close(plugin.monitorNetDirChan)
-				return
-			}
+	defer func() {
+		// Close watcher on error
+		if err != nil {
+			watcher.Close()
 		}
 	}()
 
-	<-plugin.monitorNetDirChan
+	if err = watcher.Add(confDir); err != nil {
+		return nil, fmt.Errorf("failed to add watch on %q: %v", confDir, err)
+	}
+
+	return watcher, nil
 }
 
-// InitCNI takes the plugin directory and CNI directories where the CNI config
-// files should be searched for.  If no valid CNI configs exist, network requests
-// will fail until valid CNI config files are present in the config directory.
-func InitCNI(pluginDir string, cniDirs ...string) (CNIPlugin, error) {
-	vendorCNIDirPrefix := ""
+func (plugin *cniNetworkPlugin) monitorConfDir(start *sync.WaitGroup) {
+	start.Done()
+	plugin.done.Add(1)
+	defer plugin.done.Done()
+	for {
+		select {
+		case event := <-plugin.watcher.Events:
+			logrus.Warningf("CNI monitoring event %v", event)
+
+			var defaultDeleted bool
+			createWrite := (event.Op&fsnotify.Create == fsnotify.Create ||
+				event.Op&fsnotify.Write == fsnotify.Write)
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
+				// Care about the event if the default network
+				// was just deleted
+				defNet := plugin.getDefaultNetwork()
+				if defNet != nil && event.Name == defNet.filePath {
+					defaultDeleted = true
+				}
+
+			}
+			if !createWrite && !defaultDeleted {
+				continue
+			}
+
+			if err := plugin.syncNetworkConfig(); err != nil {
+				logrus.Errorf("CNI config loading failed, continue monitoring: %v", err)
+				continue
+			}
+
+		case err := <-plugin.watcher.Errors:
+			if err == nil {
+				continue
+			}
+			logrus.Errorf("CNI monitoring error %v", err)
+			return
+
+		case <-plugin.shutdownChan:
+			return
+		}
+	}
+}
+
+// InitCNI takes a binary directory in which to search for CNI plugins, and
+// a configuration directory in which to search for CNI JSON config files.
+// If no valid CNI configs exist, network requests will fail until valid CNI
+// config files are present in the config directory.
+// If defaultNetName is not empty, a CNI config with that network name will
+// be used as the default CNI network, and container network operations will
+// fail until that network config is present and valid.
+func InitCNI(defaultNetName string, confDir string, binDirs ...string) (CNIPlugin, error) {
+	return initCNI(nil, "", defaultNetName, confDir, binDirs...)
+}
+
+// Internal function to allow faking out exec functions for testing
+func initCNI(exec cniinvoke.Exec, cacheDir, defaultNetName string, confDir string, binDirs ...string) (CNIPlugin, error) {
+	if confDir == "" {
+		confDir = DefaultConfDir
+	}
+	if len(binDirs) == 0 {
+		binDirs = []string{DefaultBinDir}
+	}
 	plugin := &cniNetworkPlugin{
-		defaultNetwork:     nil,
-		loNetwork:          getLoNetwork(cniDirs, vendorCNIDirPrefix),
-		pluginDir:          pluginDir,
-		cniDirs:            cniDirs,
-		vendorCNIDirPrefix: vendorCNIDirPrefix,
-		monitorNetDirChan:  make(chan struct{}),
-		pods:               make(map[string]*podLock),
+		defaultNetName: defaultNetName,
+		networks:       make(map[string]*cniNetwork),
+		loNetwork:      getLoNetwork(exec, binDirs),
+		confDir:        confDir,
+		binDirs:        binDirs,
+		shutdownChan:   make(chan struct{}),
+		done:           &sync.WaitGroup{},
+		pods:           make(map[string]*podLock),
+		exec:           exec,
+		cacheDir:       cacheDir,
+	}
+
+	if exec == nil {
+		exec = &cniinvoke.DefaultExec{
+			RawExec:       &cniinvoke.RawExec{Stderr: os.Stderr},
+			PluginDecoder: cniversion.PluginDecoder{},
+		}
 	}
 
 	nsm, err := newNSManager()
@@ -175,32 +222,36 @@ func InitCNI(pluginDir string, cniDirs ...string) (CNIPlugin, error) {
 	}
 	plugin.nsManager = nsm
 
-	// Ensure plugin directory exists, because the following monitoring logic
-	// relies on that.
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+	plugin.syncNetworkConfig()
+
+	plugin.watcher, err = newWatcher(plugin.confDir)
+	if err != nil {
 		return nil, err
 	}
 
-	go plugin.monitorNetDir()
+	startWg := sync.WaitGroup{}
+	startWg.Add(1)
+	go plugin.monitorConfDir(&startWg)
+	startWg.Wait()
 
 	return plugin, nil
 }
 
-func getDefaultCNINetwork(pluginDir string, cniDirs []string, vendorCNIDirPrefix string) (*cniNetwork, error) {
-	if pluginDir == "" {
-		pluginDir = DefaultNetDir
-	}
-	if len(cniDirs) == 0 {
-		cniDirs = []string{DefaultCNIDir}
+func (plugin *cniNetworkPlugin) Shutdown() error {
+	close(plugin.shutdownChan)
+	plugin.watcher.Close()
+	plugin.done.Wait()
+	return nil
+}
+
+func loadNetworks(exec cniinvoke.Exec, confDir string, binDirs []string) (map[string]*cniNetwork, string, error) {
+	files, err := libcni.ConfFiles(confDir, []string{".conf", ".conflist", ".json"})
+	if err != nil {
+		return nil, "", err
 	}
 
-	files, err := libcni.ConfFiles(pluginDir, []string{".conf", ".conflist", ".json"})
-	switch {
-	case err != nil:
-		return nil, err
-	case len(files) == 0:
-		return nil, errMissingDefaultNetwork
-	}
+	networks := make(map[string]*cniNetwork)
+	defaultNetName := ""
 
 	sort.Strings(files)
 	for _, confFile := range files {
@@ -231,27 +282,28 @@ func getDefaultCNINetwork(pluginDir string, cniDirs []string, vendorCNIDirPrefix
 			logrus.Warningf("CNI config list %s has no networks, skipping", confFile)
 			continue
 		}
-		logrus.Infof("CNI network %s (type=%v) is used from %s", confList.Name, confList.Plugins[0].Network.Type, confFile)
-		// Search for vendor-specific plugins as well as default plugins in the CNI codebase.
-		vendorDir := vendorCNIDir(vendorCNIDirPrefix, confList.Plugins[0].Network.Type)
-		cninet := &libcni.CNIConfig{
-			Path: append(cniDirs, vendorDir),
+		if confList.Name == "" {
+			confList.Name = path.Base(confFile)
 		}
-		network := &cniNetwork{name: confList.Name, NetworkConfig: confList, CNIConfig: cninet}
-		return network, nil
+
+		logrus.Infof("Found CNI network %s (type=%v) at %s", confList.Name, confList.Plugins[0].Network.Type, confFile)
+
+		networks[confList.Name] = &cniNetwork{
+			name:          confList.Name,
+			filePath:      confFile,
+			NetworkConfig: confList,
+			CNIConfig:     libcni.NewCNIConfig(binDirs, exec),
+		}
+
+		if defaultNetName == "" {
+			defaultNetName = confList.Name
+		}
 	}
-	return nil, fmt.Errorf("No valid networks found in %s", pluginDir)
+
+	return networks, defaultNetName, nil
 }
 
-func vendorCNIDir(prefix, pluginType string) string {
-	return fmt.Sprintf(VendorCNIDirTemplate, prefix, pluginType)
-}
-
-func getLoNetwork(cniDirs []string, vendorDirPrefix string) *cniNetwork {
-	if len(cniDirs) == 0 {
-		cniDirs = []string{DefaultCNIDir}
-	}
-
+func getLoNetwork(exec cniinvoke.Exec, binDirs []string) *cniNetwork {
 	loConfig, err := libcni.ConfListFromBytes([]byte(`{
   "cniVersion": "0.2.0",
   "name": "cni-loopback",
@@ -264,45 +316,62 @@ func getLoNetwork(cniDirs []string, vendorDirPrefix string) *cniNetwork {
 		// catch this
 		panic(err)
 	}
-	vendorDir := vendorCNIDir(vendorDirPrefix, loConfig.Plugins[0].Network.Type)
-	cninet := &libcni.CNIConfig{
-		Path: append(cniDirs, vendorDir),
-	}
 	loNetwork := &cniNetwork{
 		name:          "lo",
 		NetworkConfig: loConfig,
-		CNIConfig:     cninet,
+		CNIConfig:     libcni.NewCNIConfig(binDirs, exec),
 	}
 
 	return loNetwork
 }
 
 func (plugin *cniNetworkPlugin) syncNetworkConfig() error {
-	network, err := getDefaultCNINetwork(plugin.pluginDir, plugin.cniDirs, plugin.vendorCNIDirPrefix)
+	networks, defaultNetName, err := loadNetworks(plugin.exec, plugin.confDir, plugin.binDirs)
 	if err != nil {
-		logrus.Errorf("error updating cni config: %s", err)
 		return err
 	}
-	plugin.setDefaultNetwork(network)
+
+	plugin.Lock()
+	defer plugin.Unlock()
+	if plugin.defaultNetName == "" {
+		plugin.defaultNetName = defaultNetName
+	}
+	plugin.networks = networks
 
 	return nil
 }
 
-func (plugin *cniNetworkPlugin) getDefaultNetwork() *cniNetwork {
+func (plugin *cniNetworkPlugin) getNetwork(name string) (*cniNetwork, error) {
 	plugin.RLock()
 	defer plugin.RUnlock()
-	return plugin.defaultNetwork
+	net, ok := plugin.networks[name]
+	if !ok {
+		return nil, fmt.Errorf("CNI network %q not found", name)
+	}
+	return net, nil
 }
 
-func (plugin *cniNetworkPlugin) setDefaultNetwork(n *cniNetwork) {
-	plugin.Lock()
-	defer plugin.Unlock()
-	plugin.defaultNetwork = n
+func (plugin *cniNetworkPlugin) getDefaultNetworkName() string {
+	plugin.RLock()
+	defer plugin.RUnlock()
+	return plugin.defaultNetName
 }
 
-func (plugin *cniNetworkPlugin) checkInitialized() error {
-	if plugin.getDefaultNetwork() == nil {
-		return errors.New("cni config uninitialized")
+func (plugin *cniNetworkPlugin) getDefaultNetwork() *cniNetwork {
+	defaultNetName := plugin.getDefaultNetworkName()
+	if defaultNetName == "" {
+		return nil
+	}
+	network, _ := plugin.getNetwork(defaultNetName)
+	return network
+}
+
+// networksAvailable returns an error if the pod requests no networks and the
+// plugin has no default network, and thus the plugin has no idea what network
+// to attach the pod to.
+func (plugin *cniNetworkPlugin) networksAvailable(podNetwork *PodNetwork) error {
+	if len(podNetwork.Networks) == 0 && plugin.getDefaultNetwork() == nil {
+		return errMissingDefaultNetwork
 	}
 	return nil
 }
@@ -311,59 +380,119 @@ func (plugin *cniNetworkPlugin) Name() string {
 	return CNIPluginName
 }
 
-func (plugin *cniNetworkPlugin) SetUpPod(podNetwork PodNetwork) (cnitypes.Result, error) {
-	if err := plugin.checkInitialized(); err != nil {
+func (plugin *cniNetworkPlugin) forEachNetwork(podNetwork *PodNetwork, forEachFunc func(*cniNetwork, string, *PodNetwork) error) error {
+	networks := podNetwork.Networks
+	if len(networks) == 0 {
+		networks = append(networks, plugin.getDefaultNetworkName())
+	}
+	for i, netName := range networks {
+		// Interface names start at "eth0" and count up for each network
+		ifName := fmt.Sprintf("eth%d", i)
+		network, err := plugin.getNetwork(netName)
+		if err != nil {
+			logrus.Errorf(err.Error())
+			return err
+		}
+		if err := forEachFunc(network, ifName, podNetwork); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (plugin *cniNetworkPlugin) SetUpPod(podNetwork PodNetwork) ([]cnitypes.Result, error) {
+	if err := plugin.networksAvailable(&podNetwork); err != nil {
 		return nil, err
 	}
 
 	plugin.podLock(podNetwork).Lock()
 	defer plugin.podUnlock(podNetwork)
 
-	_, err := plugin.loNetwork.addToNetwork(podNetwork)
+	_, err := plugin.loNetwork.addToNetwork(plugin.cacheDir, &podNetwork, "lo")
 	if err != nil {
 		logrus.Errorf("Error while adding to cni lo network: %s", err)
 		return nil, err
 	}
 
-	result, err := plugin.getDefaultNetwork().addToNetwork(podNetwork)
-	if err != nil {
-		logrus.Errorf("Error while adding to cni network: %s", err)
+	results := make([]cnitypes.Result, 0)
+	if err := plugin.forEachNetwork(&podNetwork, func(network *cniNetwork, ifName string, podNetwork *PodNetwork) error {
+		result, err := network.addToNetwork(plugin.cacheDir, podNetwork, ifName)
+		if err != nil {
+			logrus.Errorf("Error while adding pod to CNI network %q: %s", network.name, err)
+			return err
+		}
+		results = append(results, result)
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 
-	return result, err
+	return results, nil
 }
 
 func (plugin *cniNetworkPlugin) TearDownPod(podNetwork PodNetwork) error {
-	if err := plugin.checkInitialized(); err != nil {
+	if err := plugin.networksAvailable(&podNetwork); err != nil {
 		return err
 	}
 
 	plugin.podLock(podNetwork).Lock()
 	defer plugin.podUnlock(podNetwork)
 
-	return plugin.getDefaultNetwork().deleteFromNetwork(podNetwork)
+	return plugin.forEachNetwork(&podNetwork, func(network *cniNetwork, ifName string, podNetwork *PodNetwork) error {
+		if err := network.deleteFromNetwork(plugin.cacheDir, podNetwork, ifName); err != nil {
+			logrus.Errorf("Error while removing pod from CNI network %q: %s", network.name, err)
+			return err
+		}
+		return nil
+	})
 }
 
-// TODO: Use the addToNetwork function to obtain the IP of the Pod. That will assume idempotent ADD call to the plugin.
-// Also fix the runtime's call to Status function to be done only in the case that the IP is lost, no need to do periodic calls
-func (plugin *cniNetworkPlugin) GetPodNetworkStatus(podNetwork PodNetwork) (string, error) {
+// GetPodNetworkStatus returns IP addressing and interface details for all
+// networks attached to the pod.
+func (plugin *cniNetworkPlugin) GetPodNetworkStatus(podNetwork PodNetwork) ([]cnitypes.Result, error) {
 	plugin.podLock(podNetwork).Lock()
 	defer plugin.podUnlock(podNetwork)
 
-	ip, err := getContainerIP(plugin.nsManager, podNetwork.NetNS, DefaultInterfaceName, "-4")
-	if err != nil {
-		ip, err = getContainerIP(plugin.nsManager, podNetwork.NetNS, DefaultInterfaceName, "-6")
-	}
-	if err != nil {
-		return "", err
+	results := make([]cnitypes.Result, 0)
+	if err := plugin.forEachNetwork(&podNetwork, func(network *cniNetwork, ifName string, podNetwork *PodNetwork) error {
+		version := "4"
+		ip, mac, err := getContainerDetails(plugin.nsManager, podNetwork.NetNS, ifName, "-4")
+		if err != nil {
+			ip, mac, err = getContainerDetails(plugin.nsManager, podNetwork.NetNS, ifName, "-6")
+			if err != nil {
+				return err
+			}
+			version = "6"
+		}
+
+		// Until CNI's GET request lands, construct the Result manually
+		results = append(results, &cnicurrent.Result{
+			CNIVersion: "0.3.1",
+			Interfaces: []*cnicurrent.Interface{
+				{
+					Name:    ifName,
+					Mac:     mac.String(),
+					Sandbox: podNetwork.NetNS,
+				},
+			},
+			IPs: []*cnicurrent.IPConfig{
+				{
+					Version:   version,
+					Interface: cnicurrent.Int(0),
+					Address:   *ip,
+				},
+			},
+		})
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
-	return ip.String(), nil
+	return results, nil
 }
 
-func (network *cniNetwork) addToNetwork(podNetwork PodNetwork) (cnitypes.Result, error) {
-	rt, err := buildCNIRuntimeConf(podNetwork)
+func (network *cniNetwork) addToNetwork(cacheDir string, podNetwork *PodNetwork, ifName string) (cnitypes.Result, error) {
+	rt, err := buildCNIRuntimeConf(cacheDir, podNetwork, ifName)
 	if err != nil {
 		logrus.Errorf("Error adding network: %v", err)
 		return nil, err
@@ -380,8 +509,8 @@ func (network *cniNetwork) addToNetwork(podNetwork PodNetwork) (cnitypes.Result,
 	return res, nil
 }
 
-func (network *cniNetwork) deleteFromNetwork(podNetwork PodNetwork) error {
-	rt, err := buildCNIRuntimeConf(podNetwork)
+func (network *cniNetwork) deleteFromNetwork(cacheDir string, podNetwork *PodNetwork, ifName string) error {
+	rt, err := buildCNIRuntimeConf(cacheDir, podNetwork, ifName)
 	if err != nil {
 		logrus.Errorf("Error deleting network: %v", err)
 		return err
@@ -397,13 +526,14 @@ func (network *cniNetwork) deleteFromNetwork(podNetwork PodNetwork) error {
 	return nil
 }
 
-func buildCNIRuntimeConf(podNetwork PodNetwork) (*libcni.RuntimeConf, error) {
+func buildCNIRuntimeConf(cacheDir string, podNetwork *PodNetwork, ifName string) (*libcni.RuntimeConf, error) {
 	logrus.Infof("Got pod network %+v", podNetwork)
 
 	rt := &libcni.RuntimeConf{
 		ContainerID: podNetwork.ID,
 		NetNS:       podNetwork.NetNS,
-		IfName:      DefaultInterfaceName,
+		CacheDir:    cacheDir,
+		IfName:      ifName,
 		Args: [][2]string{
 			{"IgnoreUnknown", "1"},
 			{"K8S_POD_NAMESPACE", podNetwork.Namespace},
@@ -423,5 +553,8 @@ func buildCNIRuntimeConf(podNetwork PodNetwork) (*libcni.RuntimeConf, error) {
 }
 
 func (plugin *cniNetworkPlugin) Status() error {
-	return plugin.checkInitialized()
+	if plugin.getDefaultNetwork() == nil {
+		return errMissingDefaultNetwork
+	}
+	return nil
 }

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/types.go
@@ -36,6 +36,10 @@ type PodNetwork struct {
 	NetNS string
 	// PortMappings is the port mapping of the sandbox.
 	PortMappings []PortMapping
+
+	// Networks is a list of CNI network names to attach to the sandbox
+	// Leave this list empty to attach the default network to the sandbox
+	Networks []string
 }
 
 // CNIPlugin is the interface that needs to be implemented by a plugin
@@ -47,14 +51,17 @@ type CNIPlugin interface {
 	// SetUpPod is the method called after the sandbox container of
 	// the pod has been created but before the other containers of the
 	// pod are launched.
-	SetUpPod(network PodNetwork) (types.Result, error)
+	SetUpPod(network PodNetwork) ([]types.Result, error)
 
 	// TearDownPod is the method called before a pod's sandbox container will be deleted
 	TearDownPod(network PodNetwork) error
 
 	// Status is the method called to obtain the ipv4 or ipv6 addresses of the pod sandbox
-	GetPodNetworkStatus(network PodNetwork) (string, error)
+	GetPodNetworkStatus(network PodNetwork) ([]types.Result, error)
 
 	// NetworkStatus returns error if the network plugin is in error state
 	Status() error
+
+	// Shutdown terminates all driver operations
+	Shutdown() error
 }

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/types_unix.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/types_unix.go
@@ -3,10 +3,8 @@
 package ocicni
 
 const (
-	// DefaultNetDir is the place to look for CNI Network
-	DefaultNetDir = "/etc/cni/net.d"
-	// DefaultCNIDir is the place to look for cni config files
-	DefaultCNIDir = "/opt/cni/bin"
-	// VendorCNIDirTemplate is the template for looking up vendor specific cni config/executable files
-	VendorCNIDirTemplate = "%s/opt/%s/bin"
+	// DefaultConfDir is the default place to look for CNI Network
+	DefaultConfDir = "/etc/cni/net.d"
+	// DefaultBinDir is the default place to look for CNI config files
+	DefaultBinDir = "/opt/cni/bin"
 )

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/types_windows.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/types_windows.go
@@ -3,10 +3,8 @@
 package ocicni
 
 const (
-	// DefaultNetDir is the place to look for CNI Network
-	DefaultNetDir = "C:\\cni\\etc\\net.d"
-	// DefaultCNIDir is the place to look for cni config files
-	DefaultCNIDir = "C:\\cni\\bin"
-	// VendorCNIDirTemplate is the template for looking up vendor specific cni config/executable files
-	VendorCNIDirTemplate = "C:\\cni\\%s\\opt\\%s\\bin" // XXX(vbatts) Not sure what to do here ...
+	// DefaultConfDir is the default place to look for CNI Network
+	DefaultConfDir = "C:\\cni\\etc\\net.d"
+	// DefaultBinDir is the default place to look for cni config files
+	DefaultBinDir = "C:\\cni\\bin"
 )

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/util_linux.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/util_linux.go
@@ -21,26 +21,51 @@ func (nsm *nsManager) init() error {
 	return err
 }
 
-func getContainerIP(nsm *nsManager, netnsPath, interfaceName, addrType string) (net.IP, error) {
+func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
 	// Try to retrieve ip inside container network namespace
 	output, err := exec.Command(nsm.nsenterPath, fmt.Sprintf("--net=%s", netnsPath), "-F", "--",
 		"ip", "-o", addrType, "addr", "show", "dev", interfaceName, "scope", "global").CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("Unexpected command output %s with error: %v", output, err)
+		return nil, nil, fmt.Errorf("Unexpected command output %s with error: %v", output, err)
 	}
 
 	lines := strings.Split(string(output), "\n")
 	if len(lines) < 1 {
-		return nil, fmt.Errorf("Unexpected command output %s", output)
+		return nil, nil, fmt.Errorf("Unexpected command output %s", output)
 	}
 	fields := strings.Fields(lines[0])
 	if len(fields) < 4 {
-		return nil, fmt.Errorf("Unexpected address output %s ", lines[0])
+		return nil, nil, fmt.Errorf("Unexpected address output %s ", lines[0])
 	}
-	ip, _, err := net.ParseCIDR(fields[3])
+	ip, ipNet, err := net.ParseCIDR(fields[3])
 	if err != nil {
-		return nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
+		return nil, nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
+	}
+	if ip.To4() == nil {
+		ipNet.IP = ip
+	} else {
+		ipNet.IP = ip.To4()
 	}
 
-	return ip, nil
+	// Try to retrieve MAC inside container network namespace
+	output, err = exec.Command(nsm.nsenterPath, fmt.Sprintf("--net=%s", netnsPath), "-F", "--",
+		"ip", "link", "show", "dev", interfaceName).CombinedOutput()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unexpected 'ip link' command output %s with error: %v", output, err)
+	}
+
+	lines = strings.Split(string(output), "\n")
+	if len(lines) < 2 {
+		return nil, nil, fmt.Errorf("unexpected 'ip link' command output %s", output)
+	}
+	fields = strings.Fields(lines[1])
+	if len(fields) < 4 {
+		return nil, nil, fmt.Errorf("unexpected link output %s ", lines[0])
+	}
+	mac, err := net.ParseMAC(fields[1])
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse MAC from output %s due to %v", output, err)
+	}
+
+	return ipNet, &mac, nil
 }

--- a/vendor/github.com/cri-o/ocicni/pkg/ocicni/util_unsupported.go
+++ b/vendor/github.com/cri-o/ocicni/pkg/ocicni/util_unsupported.go
@@ -14,6 +14,6 @@ func (nsm *nsManager) init() error {
 	return nil
 }
 
-func getContainerIP(nsm *nsManager, netnsPath, interfaceName, addrType string) (net.IP, error) {
-	return nil, fmt.Errorf("not supported yet")
+func getContainerDetails(nsm *nsManager, netnsPath, interfaceName, addrType string) (*net.IPNet, *net.HardwareAddr, error) {
+	return nil, nil, fmt.Errorf("not supported yet")
 }


### PR DESCRIPTION
trash update ocicni and containernetworking/cni to v0.1.0 and
0.7.0-alpha0, respectively.

ocicni v0.1.0 brings a support for multi-network but that is
"crippled" in networkStart(). The reason is there's no mechanism
in Sandbox to provide multiple networks.

**- What I did**

pulled in ocicni and containernetworking/cni updates using trash. The goal was to 
have "ocicni: missing default network is not a hard error" included to be able
to use containers with loopback networks only.  The testing shows that it did not
bring the desired functionality and something else is still needed since pods fail
to start. 

Fixes: #1809 
