### PR TITLE
[release-1.11] runPodSandbox: clean up containers on error path

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -794,6 +794,23 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			// Clean-up steps from RemovePodSanbox
+			timeout := int64(10)
+			if err2 := s.Runtime().StopContainer(ctx, container, timeout); err2 != nil {
+				logrus.Warnf("failed to stop container %s: %v", container.Name(), err2)
+			}
+			if err2 := s.Runtime().WaitContainerStateStopped(ctx, container, timeout); err2 != nil {
+				logrus.Warnf("failed to get container 'stopped' status %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
+			}
+			if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
+				logrus.Warnf("failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
+			}
+			s.ContainerStateToDisk(container)
+		}
+	}()
+
 	s.ContainerStateToDisk(container)
 
 	if !s.config.Config.ManageNetworkNSLifecycle {


### PR DESCRIPTION
If the CNI setup fails in runPodSandbox, the infra container started is
not stopped/removed and leaks.

Ensure the necessary clean-up steps are executed on error
path.

Fixes: #1816 