### PR TITLE
Don't use runc kill -all

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -682,7 +682,7 @@ func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64
 		logrus.Warnf("Stop container %q timed out: %v", c.id, err)
 	}
 
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.Path(c), "kill", "--all", c.id, "KILL"); err != nil {
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, r.Path(c), "kill", c.id, "KILL"); err != nil {
 		if err := checkProcessGone(c); err != nil {
 			return fmt.Errorf("failed to stop container %q: %v", c.id, err)
 		}


### PR DESCRIPTION
#1833 for master @runcom PTAL

Killing the main container process should kill the other processes
in the pid namespace. For the shared case, the shared pid 1 would
reap the processes and remaining would be kiled when it is killed

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

