### PR TITLE
tests: enable codecov unit coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,15 @@ jobs:
         - make CONTAINER_RUNTIME=docker integration
       env: TEST_USERNS=1
       go: "1.11.x"
+    - script:
+	- make coverage
   allow_failures:
     - os: osx
     - go: tip
     - env: CROSS_PLATFORM=true
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash) -F linux
 
 notifications:
   irc: "chat.freenode.net#cri-o"

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,20 @@ integration: crioimage
 testunit:
 	$(GO) test -tags "$(BUILDTAGS) containers_image_ostree_stub" -cover $(PACKAGES)
 
+coverage:
+	@rm -f coverage.txt
+	$(GO) test -tags "$(BUILDTAGS) containers_image_ostree_stub" $(PACKAGES)
+	@( for pkg in $(PACKAGES); do \
+		$(GO) test -tags "$(BUILDTAGS) containers_image_ostree_stub" \
+			-cover \
+			-coverprofile=profile.out \
+			-covermode=atomic $$pkg || exit; \
+		if [ -f profile.out ]; then \
+			cat profile.out >> coverage.txt; \
+			rm profile.out; \
+		fi; \
+	done )
+
 localintegration: clean binaries test-binaries
 	./test/test_runner.sh ${TESTFLAGS}
 


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

add stuff to enable codecov integration

**- How I did it**

vi

**- How to verify it**

let's see if codecov correctly  reports coverage ...

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
