### PR TITLE
Allow containers/storage to manage SELinux labels

### DIFF
--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kubernetes-sigs/cri-o/oci"
 	"github.com/kubernetes-sigs/cri-o/pkg/annotations"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
@@ -175,7 +174,7 @@ func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
 	return s.StorageRuntimeServer().SetContainerMetadata(id, storageMetadata)
 }
 
-func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string, string, error) {
+func getLabelOptions(selinuxOptions *pb.SELinuxOption) []string {
 	labels := []string{}
 	if selinuxOptions != nil {
 		if selinuxOptions.User != "" {
@@ -191,18 +190,7 @@ func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string
 			labels = append(labels, "level:"+selinuxOptions.Level)
 		}
 	}
-	var (
-		processLabel, mountLabel string
-		err                      error
-	)
-	processLabel, mountLabel, err = label.InitLabels(labels)
-	if err != nil {
-		return "", "", err
-	}
-	if privileged {
-		processLabel = ""
-	}
-	return processLabel, mountLabel, nil
+	return labels
 }
 
 // convertCgroupFsNameToSystemd converts an expanded cgroupfs name to its systemd name.

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/kubernetes-sigs/cri-o/lib/sandbox"
 	"github.com/kubernetes-sigs/cri-o/oci"
-	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -112,10 +111,6 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		if err := sb.NetNsRemove(); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := label.ReleaseLabel(sb.ProcessLabel()); err != nil {
-		return nil, err
 	}
 
 	// unmount the shm for the pod


### PR DESCRIPTION
This patch set moves the management of SELinux labels down into containers/storage so that CRI-O, Buildah and Podman will not overlay on their container labels.