### PR TITLE
conmon: fix case when symlink == max UNIX socket path

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -1197,6 +1197,16 @@ static char *setup_attach_socket(void)
 	if (unlink(attach_symlink_dir_path) == -1 && errno != ENOENT)
 		pexit("Failed to remove existing symlink for attach socket directory");
 
+	/*
+	 * This is to address a corner case where the symlink path length can end up to be
+	 * the same as the socket.  When it happens, the symlink prevents the socket to be
+	 * be created.  This could still be a problem with other containers, but it is safe
+	 * to assume the CUUIDs don't change length in the same directory.  As a workaround,
+	 *  in such case, make the symlink one char shorter.
+	 */
+	if (strlen(attach_symlink_dir_path) == (sizeof(attach_addr.sun_path) - 1))
+		attach_symlink_dir_path[sizeof(attach_addr.sun_path) - 2] = '\0';
+
 	if (symlink(opt_bundle_path, attach_symlink_dir_path) == -1)
 		pexit("Failed to create symlink for attach socket");
 


### PR DESCRIPTION
address a corner case where the symlink path length can end up to be
the same as the socket.  When it happens, the symlink prevents the
socket to be be created.  This could still be a problem with other
containers, but it is safe to assume the CUUIDs don't change length in
the same directory.  As a workaround, in such case, make the symlink
one char shorter.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
