### PR TITLE
systemd: add support for a crio-metrics sysconfig file.

### DIFF
--- a/contrib/sysconfig/crio
+++ b/contrib/sysconfig/crio
@@ -1,0 +1,7 @@
+# /etc/sysconfig/crio
+
+# use "--enable-metrics" and "--metrics-port value"
+#CRIO_METRICS_OPTIONS="--enable-metrics"
+
+#CRIO_NETWORK_OPTIONS=
+#CRIO_STORAGE_OPTIONS=

--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -5,12 +5,12 @@ After=network-online.target
 
 [Service]
 Type=notify
-EnvironmentFile=-/etc/sysconfig/crio-storage
-EnvironmentFile=-/etc/sysconfig/crio-network
+EnvironmentFile=-/etc/sysconfig/crio
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/local/bin/crio \
           $CRIO_STORAGE_OPTIONS \
-          $CRIO_NETWORK_OPTIONS
+          $CRIO_NETWORK_OPTIONS \
+          $CRIO_METRICS_OPTIONS
 ExecReload=/bin/kill -s HUP $MAINPID
 TasksMax=infinity
 LimitNOFILE=1048576


### PR DESCRIPTION
Adapt our unit file so that metrics options can be defined.
Starting crio with --enable-metrics exposes Prometheus-compatible metrics.

Sample /etc/sysconfig-metrics file:

~~~
# /etc/sysconfig/crio-metrics
# "--enable-metrics" and "--metrics-port value"

CRIO_METRICS_OPTIONS=
~~~

Verifying that crio starts with metrics can be done with netstat:
~~~
# netstat -ntaupe |grep 9090
tcp6       0      0 :::9090                 :::*                    LISTEN      0          8473135    15496/crio 
~~~
Signed-off-by: François Cami <fcami@fedoraproject.org>


