### PR TITLE
container_create: fix dev mounts and remove nodev from every mount

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -61,6 +61,33 @@ func (m orderedMounts) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].Destination), string(os.PathSeparator))
 }
 
+// mounts defines how to sort runtime.Mount.
+// This is the same with the Docker implementation:
+//   https://github.com/moby/moby/blob/17.05.x/daemon/volumes.go#L26
+type criOrderedMounts []*pb.Mount
+
+// Len returns the number of mounts. Used in sorting.
+func (m criOrderedMounts) Len() int {
+	return len(m)
+}
+
+// Less returns true if the number of parts (a/b/c would be 3 parts) in the
+// mount indexed by parameter 1 is less than that of the mount indexed by
+// parameter 2. Used in sorting.
+func (m criOrderedMounts) Less(i, j int) bool {
+	return m.parts(i) < m.parts(j)
+}
+
+// Swap swaps two items in an array of mounts. Used in sorting
+func (m criOrderedMounts) Swap(i, j int) {
+	m[i], m[j] = m[j], m[i]
+}
+
+// parts returns the number of parts in the destination of a mount. Used in sorting.
+func (m criOrderedMounts) parts(i int) int {
+	return strings.Count(filepath.Clean(m[i].ContainerPath), string(os.PathSeparator))
+}
+
 // Ensure mount point on which path is mounted, is shared.
 func ensureShared(path string, mountInfos []*dockermounts.Info) error {
 	sourceMount, optionalOpts, err := getSourceMount(path, mountInfos)

--- a/server/container_create_linux_test.go
+++ b/server/container_create_linux_test.go
@@ -1,0 +1,45 @@
+// +build linux
+
+package server
+
+import (
+	"testing"
+
+	"github.com/opencontainers/runtime-tools/generate"
+	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func TestAddOCIBindsForDev(t *testing.T) {
+	specgen, err := generate.New("linux")
+	if err != nil {
+
+		t.Error(err)
+	}
+	config := &pb.ContainerConfig{
+		Mounts: []*pb.Mount{
+			{
+				ContainerPath: "/dev",
+				HostPath:      "/dev",
+			},
+		},
+	}
+	_, binds, err := addOCIBindMounts("", config, &specgen, "")
+	if err != nil {
+		t.Error(err)
+	}
+	for _, m := range specgen.Mounts() {
+		if m.Destination == "/dev" {
+			t.Error("/dev shouldn't be in the spec if it's bind mounted from kube")
+		}
+	}
+	var foundDev bool
+	for _, b := range binds {
+		if b.Destination == "/dev" {
+			foundDev = true
+			break
+		}
+	}
+	if !foundDev {
+		t.Error("no /dev mount found in spec mounts")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- fix #1881 
- made sure we don't add mounts in /dev where not needed
- removed nodev from every mount (I don't even remember why we did that but doesn't look right and could have caused the recent issues in kata as well

**- How I did it**

vi

**- How to verify it**

the kata job in the CI should cover this scenario and if it passes, then it's verified.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
