### PR TITLE
pkg/storage: force unmounts

### DIFF
--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -420,7 +420,7 @@ func (r *runtimeService) StopContainer(idOrName string) error {
 	if err != nil {
 		return err
 	}
-	_, err = r.storageImageServer.GetStore().Unmount(container.ID, false)
+	_, err = r.storageImageServer.GetStore().Unmount(container.ID, true)
 	if err != nil {
 		logrus.Debugf("failed to unmount container %q: %v", container.ID, err)
 		return err


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Due to a change in containers/storage, we need to force umount the
storage of a container to get back to previous behavior.

Conversation happened here: https://github.com/kubernetes-sigs/cri-o/issues/1883#issuecomment-436662573

Fix https://github.com/kubernetes-sigs/cri-o/issues/1883

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
