### PR TITLE
Cancell imageConfigDigest allong all other requests from ImageService

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -338,7 +338,7 @@ func imageSize(img types.ImageSource) *uint64 {
 }
 
 func imageConfigDigest(ctx context.Context, img types.ImageSource, instanceDigest *digest.Digest) (digest.Digest, error) {
-	manifestBytes, manifestType, err := img.GetManifest(nil, instanceDigest)
+	manifestBytes, manifestType, err := img.GetManifest(ctx, instanceDigest)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The context here (in imageConfigDigest) is to allow request canceling. The context in GetManifest interface is also to allow request canceling. These two just need to be wired together.
