### PR TITLE
[1.12] Remove nodev from mounts

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1037,10 +1037,6 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 		}
 		options = append(options, "rbind")
 
-		if !strings.HasPrefix(dest, "/dev") {
-			options = append(options, "nodev")
-		}
-
 		// mount propagation
 		mountInfos, err := dockermounts.GetMounts(nil)
 		if err != nil {


### PR DESCRIPTION
We need the ability to create overlayfs in empty dir volumes
and support similar use cases.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

