### PR TITLE
Remove nodev from mounts

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -1037,10 +1037,6 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 		}
 		options = append(options, "rbind")
 
-		if !strings.HasPrefix(dest, "/dev") {
-			options = append(options, "nodev")
-		}
-
 		// mount propagation
 		mountInfos, err := dockermounts.GetMounts(nil)
 		if err != nil {


### PR DESCRIPTION
We need the ability to create overlayfs in empty dir volumes
and support similar use cases.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
