### PR TITLE
vendor: update selinux

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/containers/storage 3161726d1db0d0d4e86a9667dd476f09b997f497
 github.com/containernetworking/cni v0.4.0
 google.golang.org/grpc 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e https://github.com/grpc/grpc-go
 google.golang.org/genproto 09f6ed296fc66555a25fe4ce95173148778dfa85
-github.com/opencontainers/selinux 077c8b6d1c18456fb7c792bc0de52295a0d1900e
+github.com/opencontainers/selinux 6ba084dd09db3dfe49a839bab0bbe97fd9274d80
 github.com/opencontainers/go-digest v1.0.0-rc0
 github.com/opencontainers/runtime-tools 1c243a8a8eb44d491790798afc9b634c6f6a6380
 github.com/opencontainers/runc 10d38b660a77168360df3522881e2dc2be5056bd

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -687,7 +687,11 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return SetFileLabel(p, label)
+		e := SetFileLabel(p, label)
+		if os.IsNotExist(e) {
+			return nil
+		}
+		return e
 	}
 
 	if recurse {


### PR DESCRIPTION
inherit a change for not failing a recursive relabelling if the file
is removed between the directory is read and the lsetxattr syscall.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
