### PR TITLE
vendor: Remove reference to github.com/juju/ratelimit

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -29,7 +29,6 @@ github.com/vishvananda/netlink master
 github.com/vishvananda/netns master
 github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runtime-spec v1.0.0
-github.com/juju/ratelimit 5b9ff866471762aa2ab2dced63c9fb6f53921342
 github.com/tchap/go-patricia v2.2.6
 gopkg.in/cheggaaa/pb.v1 v1.0.7
 gopkg.in/inf.v0 v0.9.0


### PR DESCRIPTION
It isn't being used or vendored

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

