### PR TITLE
[release-1.13] container_server: fix a segfault when the sandbox is not found

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -670,6 +670,9 @@ type containerServerState struct {
 // AddContainer adds a container to the container state store
 func (c *ContainerServer) AddContainer(ctr *oci.Container) {
 	sandbox := c.state.sandboxes.Get(ctr.Sandbox())
+	if sandbox == nil {
+		return
+	}
 	sandbox.AddContainer(ctr)
 	c.state.containers.Add(ctr.ID(), ctr)
 }
@@ -698,6 +701,9 @@ func (c *ContainerServer) HasContainer(id string) bool {
 func (c *ContainerServer) RemoveContainer(ctr *oci.Container) {
 	sbID := ctr.Sandbox()
 	sb := c.state.sandboxes.Get(sbID)
+	if sb == nil {
+		return
+	}
 	sb.RemoveContainer(ctr)
 	c.state.containers.Delete(ctr.ID())
 }
@@ -747,6 +753,9 @@ func (c *ContainerServer) GetSandbox(id string) *sandbox.Sandbox {
 // GetSandboxContainer returns a sandbox's infra container
 func (c *ContainerServer) GetSandboxContainer(id string) *oci.Container {
 	sb := c.state.sandboxes.Get(id)
+	if sb == nil {
+		return nil
+	}
 	return sb.InfraContainer()
 }
 


### PR DESCRIPTION
backport of: https://github.com/kubernetes-sigs/cri-o/pull/1955

github.com/kubernetes-sigs/cri-o/lib/sandbox.(*Sandbox).RemoveContainer(0x0, 0xc00071b380)
        /gopath/src/github.com/kubernetes-sigs/cri-o/lib/sandbox/sandbox.go:319 +0x22
github.com/kubernetes-sigs/cri-o/lib.(*ContainerServer).RemoveContainer(0xc0004dff40, 0xc00071b380)
        /gopath/src/github.com/kubernetes-sigs/cri-o/lib/container_server.go:701 +0x6e
github.com/kubernetes-sigs/cri-o/server.(*Server).removeContainer(0xc0003eb680, 0xc00071b380)
        /gopath/src/github.com/kubernetes-sigs/cri-o/server/server.go:431 +0x38
github.com/kubernetes-sigs/cri-o/server.(*Server).CreateContainer.func4(0xc000bf9b18, 0xc0003eb680, 0xc00071b380)
        /gopath/src/github.com/kubernetes-sigs/cri-o/server/container_create.go:545 +0x4a
github.com/kubernetes-sigs/cri-o/server.(*Server).CreateContainer(0xc0003eb680, 0x1a93000, 0xc000af6960, 0xc000806920, 0x0, 0x1a71ba0, 0xc0009f83f0)
        /gopath/src/github.com/kubernetes-sigs/cri-o/server/container_create.go:561 +0x795
github.com/kubernetes-sigs/cri-o/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2._RuntimeService_CreateContainer_Handler(0x1870da0, 0xc0003eb680, 0x1a93000, 0xc000af6960, 0xc000e9bd60, 0x0, 0x0, 0x0, 0x0, 0x0)

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit d6b2efb4cf2430a07483471c2877b716040ed6cd)
