### PR TITLE
Add existence check for runtime_path

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -320,6 +320,11 @@ var configCommand = cli.Command{
 			config = server.DefaultConfig()
 		}
 
+		// Validate the configuration during generation
+		if err := config.Validate(false); err != nil {
+			return err
+		}
+
 		// Output the commented config.
 		return commentedConfigTemplate.ExecuteTemplate(os.Stdout, "config", config)
 	},


### PR DESCRIPTION
Hey there :wave:, during my experiments with the `Runtimes` configuration variable I noticed that there is no check for existence of the `runtime_path`. This pull request contains an additional sanity check as well as a debug output to see which runtimes got registered during server instantiation.

For later improvements I would suggest to move the configuration validation into the `config.go` files for a better test-ability. Would you agree to that? :innocent: 
