### PR TITLE
tutorial: Update CNI plugins install example

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -223,7 +223,7 @@ cd $GOPATH/src/github.com/containernetworking/plugins
 Build the `CNI` plugins:
 
 ```
-./build.sh
+./build_linux.sh # or build_windows.sh
 ```
 
 Output:


### PR DESCRIPTION
Commit containernetworking/plugins@4e1f780 (Split build.sh into two OS-specific scripts) removes the `build.sh` file. Now we have `build_linux.sh` and `build_windows.sh`

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>
