### PR TITLE
pkg/storage/image: set insecure only on docker transport

### DIFF
--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -372,9 +372,11 @@ func (svc *imageService) prepareReference(imageName string, options *copy.Option
 		options.SourceCtx = &types.SystemContext{}
 	}
 
-	hostname := reference.Domain(srcRef.DockerReference())
-	if secure := svc.isSecureIndex(hostname); !secure {
-		options.SourceCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!secure)
+	if srcRef.DockerReference() != nil {
+		hostname := reference.Domain(srcRef.DockerReference())
+		if secure := svc.isSecureIndex(hostname); !secure {
+			options.SourceCtx.DockerInsecureSkipTLSVerify = types.NewOptionalBool(!secure)
+		}
 	}
 	return srcRef, nil
 }


### PR DESCRIPTION
fix https://github.com/kubernetes-sigs/cri-o/issues/1980

Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
