### PR TITLE
Fix segfault for invalid paths in GetDiskUsageStats()

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -11,13 +11,9 @@ func GetDiskUsageStats(path string) (uint64, uint64, error) {
 	var dirSize, inodeCount uint64
 
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		fileStat, error := os.Lstat(path)
-		if error != nil {
-			if fileStat.Mode()&os.ModeSymlink != 0 {
-				// Is a symlink; no error should be returned
-				return nil
-			}
-			return error
+		// Walk does not follow symbolic links
+		if err != nil {
+			return err
 		}
 
 		dirSize += uint64(info.Size())


### PR DESCRIPTION
Hey there, this should be a suitable fix since `os.Lstat()` will return `nil` for `FileInfo` if the path is not accessible. Furthermore the `Walk()` function already does an `os.Lstat()` which makes the additional call obsolete within our implementation. 