### PR TITLE
Add interface nil checks

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -90,6 +90,10 @@ func (DetachError) Error() string {
 
 // CopyDetachable is similar to io.Copy but support a detach key sequence to break out.
 func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, err error) {
+	// Sanity check interfaces
+	if dst == nil || src == nil {
+		return 0, fmt.Errorf("src/dst reader/writer nil")
+	}
 	if len(keys) == 0 {
 		// Default keys : ctrl-p ctrl-q
 		keys = []byte{16, 17}
@@ -111,14 +115,8 @@ func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, e
 				}
 				nr, er = src.Read(buf)
 			}
-			var nw int
-			var ew error
-			if len(preservBuf) > 0 {
-				nw, ew = dst.Write(preservBuf)
-				nr = len(preservBuf)
-			} else {
-				nw, ew = dst.Write(buf[0:nr])
-			}
+			nw, ew := dst.Write(preservBuf)
+			nr = len(preservBuf)
 			if nw > 0 {
 				written += int64(nw)
 			}
@@ -145,6 +143,9 @@ func CopyDetachable(dst io.Writer, src io.Reader, keys []byte) (written int64, e
 // of the caller. Up to 32 MB is allocated to print the
 // stack.
 func WriteGoroutineStacks(w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer nil")
+	}
 	buf := make([]byte, 1<<20)
 	for i := 0; ; i++ {
 		n := runtime.Stack(buf, true)


### PR DESCRIPTION
I added missing interface nil checks to prevent possible nil pointer dereferences. 

Beside that, I think that `preservBuf` must always be larget than 0: 
https://github.com/kubernetes-sigs/cri-o/blob/95ad21041c8a9f337673f97ecca7709daca8b8b2/utils/utils.go#L116-L121
because empty `keys` are not possible within the function:
https://github.com/kubernetes-sigs/cri-o/blob/95ad21041c8a9f337673f97ecca7709daca8b8b2/utils/utils.go#L92-L96