### PR TITLE
Remove unneeded error check

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -125,9 +125,6 @@ func New(ctx context.Context, config *Config) (*ContainerServer, error) {
 	}
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage)
-	if err != nil {
-		return nil, err
-	}
 
 	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {


### PR DESCRIPTION
Hey, since the error variable will not be modified by the preceding statement the check for `err != nil` is not needed any more.