### PR TITLE
Remove unreachable error handling paths

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -609,15 +609,9 @@ func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
 // ReserveContainerName holds a name for a container that is being created
 func (c *ContainerServer) ReserveContainerName(id, name string) (string, error) {
 	if err := c.ctrNameIndex.Reserve(name, id); err != nil {
-		if err == registrar.ErrNameReserved {
-			id, err := c.ctrNameIndex.Get(name)
-			if err != nil {
-				logrus.Warnf("conflict, ctr name %q already reserved", name)
-				return "", err
-			}
-			return "", fmt.Errorf("conflict, name %q already reserved for ctr %q", name, id)
-		}
-		return "", fmt.Errorf("error reserving ctr name %s", name)
+		err = fmt.Errorf("error reserving ctr name %s for id %s", name, id)
+		logrus.Warn(err)
+		return "", err
 	}
 	return name, nil
 }
@@ -631,15 +625,9 @@ func (c *ContainerServer) ReleaseContainerName(name string) {
 // ReservePodName holds a name for a pod that is being created
 func (c *ContainerServer) ReservePodName(id, name string) (string, error) {
 	if err := c.podNameIndex.Reserve(name, id); err != nil {
-		if err == registrar.ErrNameReserved {
-			id, err := c.podNameIndex.Get(name)
-			if err != nil {
-				logrus.Warnf("conflict, pod name %q already reserved", name)
-				return "", err
-			}
-			return "", fmt.Errorf("conflict, name %q already reserved for pod %q", name, id)
-		}
-		return "", fmt.Errorf("error reserving pod name %q", name)
+		err = fmt.Errorf("error reserving pod name %s for id %s", name, id)
+		logrus.Warn(err)
+		return "", err
 	}
 	return name, nil
 }


### PR DESCRIPTION
The only error the `Registrar` can return within the `Reserve()` function is `registrar.ErrNameReserved`. This means the lines 620 and 642 in `container_server.go` were unreachable for now. I also removed the additional `Get` since the only reason that the reservation fails is that it is already reserved.