### PR TITLE
oci: Abstract Runtime structure as a Go interface

### DIFF
--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -600,7 +600,7 @@ func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
 	}
 	defer jsonSource.Close()
 	enc := json.NewEncoder(jsonSource)
-	return enc.Encode(c.runtime.ContainerStatus(ctr))
+	return enc.Encode(ctr.State())
 }
 
 // ReserveContainerName holds a name for a container that is being created

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -582,7 +582,7 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 	}
 	// ignore errors, this is a best effort to have up-to-date info about
 	// a given container before its state gets stored
-	c.runtime.UpdateStatus(ctr)
+	c.runtime.UpdateContainerStatus(ctr)
 
 	return nil
 }
@@ -592,7 +592,7 @@ func (c *ContainerServer) ContainerStateFromDisk(ctr *oci.Container) error {
 func (c *ContainerServer) ContainerStateToDisk(ctr *oci.Container) error {
 	// ignore errors, this is a best effort to have up-to-date info about
 	// a given container before its state gets stored
-	c.Runtime().UpdateStatus(ctr)
+	c.Runtime().UpdateContainerStatus(ctr)
 
 	jsonSource, err := ioutils.NewAtomicFileWriter(ctr.StatePath(), 0644)
 	if err != nil {

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -126,7 +126,7 @@ func New(ctx context.Context, config *Config) (*ContainerServer, error) {
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage)
 
-	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.NoPivot, config.CtrStopTimeout)
+	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.NoPivot, config.CtrStopTimeout, "v1")
 	if err != nil {
 		return nil, err
 	}

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -12,7 +12,7 @@ func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Sig
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to find container %s", container)
 	}
-	c.runtime.UpdateStatus(ctr)
+	c.runtime.UpdateContainerStatus(ctr)
 	cStatus := ctr.State()
 
 	// If the container is not running, error and move on.

--- a/lib/kill.go
+++ b/lib/kill.go
@@ -13,7 +13,7 @@ func (c *ContainerServer) ContainerKill(container string, killSignal syscall.Sig
 		return "", errors.Wrapf(err, "failed to find container %s", container)
 	}
 	c.runtime.UpdateStatus(ctr)
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 
 	// If the container is not running, error and move on.
 	if cStatus.Status != oci.ContainerStateRunning {

--- a/lib/pause.go
+++ b/lib/pause.go
@@ -12,7 +12,7 @@ func (c *ContainerServer) ContainerPause(container string) (string, error) {
 		return "", errors.Wrapf(err, "failed to find container %s", container)
 	}
 
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 	if cStatus.Status != oci.ContainerStatePaused {
 		if err := c.runtime.PauseContainer(ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to pause container %s", ctr.ID())
@@ -32,7 +32,7 @@ func (c *ContainerServer) ContainerUnpause(container string) (string, error) {
 		return "", errors.Wrapf(err, "failed to find container %s", container)
 	}
 
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 	if cStatus.Status == oci.ContainerStatePaused {
 		if err := c.runtime.UnpauseContainer(ctr); err != nil {
 			return "", errors.Wrapf(err, "failed to unpause container %s", ctr.ID())

--- a/lib/remove.go
+++ b/lib/remove.go
@@ -17,7 +17,7 @@ func (c *ContainerServer) Remove(ctx context.Context, container string, force bo
 	}
 	ctrID := ctr.ID()
 
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 	switch cStatus.Status {
 	case oci.ContainerStatePaused:
 		return "", errors.Errorf("cannot remove paused container %s", ctrID)

--- a/lib/rename.go
+++ b/lib/rename.go
@@ -77,7 +77,7 @@ func (c *ContainerServer) updateStateName(ctr *oci.Container, name string) error
 	}
 	defer jsonSource.Close()
 	enc := json.NewEncoder(jsonSource)
-	return enc.Encode(c.runtime.ContainerStatus(ctr))
+	return enc.Encode(ctr.State())
 }
 
 // Attempts to update a metadata annotation

--- a/lib/stop.go
+++ b/lib/stop.go
@@ -15,7 +15,7 @@ func (c *ContainerServer) ContainerStop(ctx context.Context, container string, t
 	}
 	ctrID := ctr.ID()
 
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 	switch cStatus.Status {
 
 	case oci.ContainerStatePaused:

--- a/lib/wait.go
+++ b/lib/wait.go
@@ -8,7 +8,7 @@ import (
 
 func isStopped(c *ContainerServer, ctr *oci.Container) bool {
 	c.runtime.UpdateStatus(ctr)
-	cStatus := c.runtime.ContainerStatus(ctr)
+	cStatus := ctr.State()
 	return cStatus.Status == oci.ContainerStateStopped
 }
 

--- a/lib/wait.go
+++ b/lib/wait.go
@@ -7,7 +7,7 @@ import (
 )
 
 func isStopped(c *ContainerServer, ctr *oci.Container) bool {
-	c.runtime.UpdateStatus(ctr)
+	c.runtime.UpdateContainerStatus(ctr)
 	cStatus := ctr.State()
 	return cStatus.Status == oci.ContainerStateStopped
 }

--- a/oci/container.go
+++ b/oci/container.go
@@ -247,6 +247,11 @@ func (c *Container) State() *ContainerState {
 	return c.state
 }
 
+// StateNoLock returns the state of a container without using a lock.
+func (c *Container) StateNoLock() *ContainerState {
+	return c.state
+}
+
 // AddVolume adds a volume to list of container volumes.
 func (c *Container) AddVolume(v ContainerVolume) {
 	c.volumes = append(c.volumes, v)
@@ -303,4 +308,13 @@ func (c *Container) SetCreated() {
 // Created returns whether the container was created successfully
 func (c *Container) Created() bool {
 	return c.created
+}
+
+// SetStartFailed sets the container state appropriately after a start failure
+func (c *Container) SetStartFailed(err error) {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+	// adjust finished and started times
+	c.state.Finished, c.state.Started = c.state.Created, c.state.Created
+	c.state.Error = err.Error()
 }

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -253,24 +253,3 @@ type ExecSyncError struct {
 func (e ExecSyncError) Error() string {
 	return fmt.Sprintf("command error: %+v, stdout: %s, stderr: %s, exit code %d", e.Err, e.Stdout.Bytes(), e.Stderr.Bytes(), e.ExitCode)
 }
-
-// SetStartFailed sets the container state appropriately after a start failure
-func (r *RuntimeBase) SetStartFailed(c *Container, err error) {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-	// adjust finished and started times
-	c.state.Finished, c.state.Started = c.state.Created, c.state.Created
-	c.state.Error = err.Error()
-}
-
-// ContainerStatus returns the state of a container.
-func (r *RuntimeBase) ContainerStatus(c *Container) *ContainerState {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-	return c.state
-}
-
-// CurrentContainerStatus returns the state of a container without using a lock.
-func (r *RuntimeBase) CurrentContainerStatus(c *Container) *ContainerState {
-	return c.state
-}

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -2,30 +2,15 @@ package oci
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"net"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/docker/docker/pkg/pools"
-	"github.com/fsnotify/fsnotify"
-	"github.com/kubernetes-sigs/cri-o/pkg/findprocess"
-	"github.com/kubernetes-sigs/cri-o/utils"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/remotecommand"
-	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	utilexec "k8s.io/utils/exec"
 )
 
 const (
@@ -62,49 +47,17 @@ const (
 	UntrustedRuntime = "untrusted"
 )
 
-// New creates a new Runtime with options provided
-func New(runtimeTrustedPath string,
-	runtimeUntrustedPath string,
-	trustLevel string,
-	defaultRuntime string,
-	runtimes map[string]RuntimeHandler,
-	conmonPath string,
-	conmonEnv []string,
-	cgroupManager string,
-	containerExitsDir string,
-	containerAttachSocketDir string,
-	logSizeMax int64,
-	noPivot bool,
-	ctrStopTimeout int64) (*Runtime, error) {
-	if runtimeTrustedPath == "" {
-		// this means no "runtime" key in config as it's deprecated, fallback to
-		// the runtime handler configured as default.
-		r, ok := runtimes[defaultRuntime]
-		if !ok {
-			return nil, fmt.Errorf("no runtime configured for default_runtime=%q", defaultRuntime)
-		}
-		runtimeTrustedPath = r.RuntimePath
-	}
-	r := &Runtime{
-		name:                     filepath.Base(runtimeTrustedPath),
-		trustedPath:              runtimeTrustedPath,
-		untrustedPath:            runtimeUntrustedPath,
-		trustLevel:               trustLevel,
-		runtimes:                 runtimes,
-		conmonPath:               conmonPath,
-		conmonEnv:                conmonEnv,
-		cgroupManager:            cgroupManager,
-		containerExitsDir:        containerExitsDir,
-		containerAttachSocketDir: containerAttachSocketDir,
-		logSizeMax:               logSizeMax,
-		noPivot:                  noPivot,
-		ctrStopTimeout:           ctrStopTimeout,
-	}
-	return r, nil
+// Runtime is the generic structure holding both global and specific
+// information about the runtime through RuntimeBase and RuntimeImpl
+// respectively.
+type Runtime struct {
+	RuntimeBase
+	RuntimeImpl
 }
 
-// Runtime stores the information about a oci runtime
-type Runtime struct {
+// RuntimeBase gathers informations that can be shared across Runtime
+// implementations.
+type RuntimeBase struct {
 	name                     string
 	trustedPath              string
 	untrustedPath            string
@@ -120,37 +73,111 @@ type Runtime struct {
 	ctrStopTimeout           int64
 }
 
+// RuntimeImpl is an interface used by the caller to interact with the
+// container runtime. The purpose of this interface being to abstract
+// implementations and their associated assumptions regarding the way to
+// interact with containers. This will allow for new implementations of
+// this interface, especially useful for the case of VM based container
+// runtimes. Assumptions based on the fact that a container process runs
+// on the host will be limited to the RuntimeV1 implementation.
+type RuntimeImpl interface {
+	Version() (string, error)
+	CreateContainer(*Container, string) error
+	StartContainer(*Container) error
+	Exec(*Container, []string, io.Reader, io.WriteCloser, io.WriteCloser,
+		bool, <-chan remotecommand.TerminalSize) error
+	ExecSync(*Container, []string, int64) (*ExecSyncResponse, error)
+	UpdateContainer(*Container, *rspec.LinuxResources) error
+	WaitContainerStateStopped(context.Context, *Container) error
+	StopContainer(context.Context, *Container, int64) error
+	DeleteContainer(*Container) error
+	UpdateStatus(*Container) error
+	PauseContainer(*Container) error
+	UnpauseContainer(*Container) error
+	ContainerStats(*Container) (*ContainerStats, error)
+	SignalContainer(*Container, syscall.Signal) error
+	AttachContainer(*Container, io.Reader, io.Writer, io.Writer, bool,
+		<-chan remotecommand.TerminalSize) error
+	PortForwardContainer(*Container, int32, io.ReadWriter) error
+	ReopenContainerLog(*Container) error
+}
+
 // RuntimeHandler represents each item of the "crio.runtime.runtimes" TOML
 // config table.
 type RuntimeHandler struct {
 	RuntimePath string `toml:"runtime_path"`
 }
 
-// syncInfo is used to return data from monitor process to daemon
-type syncInfo struct {
-	Pid     int    `json:"pid"`
-	Message string `json:"message,omitempty"`
+// New creates a new Runtime with options provided
+func New(runtimeTrustedPath string,
+	runtimeUntrustedPath string,
+	trustLevel string,
+	defaultRuntime string,
+	runtimes map[string]RuntimeHandler,
+	conmonPath string,
+	conmonEnv []string,
+	cgroupManager string,
+	containerExitsDir string,
+	containerAttachSocketDir string,
+	logSizeMax int64,
+	noPivot bool,
+	ctrStopTimeout int64,
+	runtimeVersion string) (*Runtime, error) {
+	if runtimeTrustedPath == "" {
+		// this means no "runtime" key in config as it's deprecated, fallback to
+		// the runtime handler configured as default.
+		r, ok := runtimes[defaultRuntime]
+		if !ok {
+			return nil, fmt.Errorf("no runtime configured for default_runtime=%q", defaultRuntime)
+		}
+		runtimeTrustedPath = r.RuntimePath
+	}
+
+	rb := RuntimeBase{
+		name:                     filepath.Base(runtimeTrustedPath),
+		trustedPath:              runtimeTrustedPath,
+		untrustedPath:            runtimeUntrustedPath,
+		trustLevel:               trustLevel,
+		runtimes:                 runtimes,
+		conmonPath:               conmonPath,
+		conmonEnv:                conmonEnv,
+		cgroupManager:            cgroupManager,
+		containerExitsDir:        containerExitsDir,
+		containerAttachSocketDir: containerAttachSocketDir,
+		logSizeMax:               logSizeMax,
+		noPivot:                  noPivot,
+		ctrStopTimeout:           ctrStopTimeout,
+	}
+
+	ri, err := newRuntimeImpl(runtimeVersion, rb)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Runtime{
+		RuntimeBase: rb,
+		RuntimeImpl: ri,
+	}, nil
 }
 
-// exitCodeInfo is used to return the monitored process exit code to the daemon
-type exitCodeInfo struct {
-	ExitCode int32  `json:"exit_code"`
-	Message  string `json:"message,omitempty"`
+// newRuntimeImpl creates a new Runtime implementation based on the version.
+func newRuntimeImpl(runtimeVersion string, rb RuntimeBase) (RuntimeImpl, error) {
+	return NewRuntimeV1(rb)
 }
 
 // Name returns the name of the OCI Runtime
-func (r *Runtime) Name() string {
+func (r *RuntimeBase) Name() string {
 	return r.name
 }
 
 // Runtimes returns the map of OCI runtimes.
-func (r *Runtime) Runtimes() map[string]RuntimeHandler {
+func (r *RuntimeBase) Runtimes() map[string]RuntimeHandler {
 	return r.runtimes
 }
 
 // ValidateRuntimeHandler returns an error if the runtime handler string
 // provided does not match any valid use case.
-func (r *Runtime) ValidateRuntimeHandler(handler string) (RuntimeHandler, error) {
+func (r *RuntimeBase) ValidateRuntimeHandler(handler string) (RuntimeHandler, error) {
 	if handler == "" {
 		return RuntimeHandler{}, fmt.Errorf("empty runtime handler")
 	}
@@ -172,10 +199,10 @@ func (r *Runtime) ValidateRuntimeHandler(handler string) (RuntimeHandler, error)
 	return runtimeHandler, nil
 }
 
-// Path returns the full path the OCI Runtime executable.
+// path returns the full path the OCI Runtime executable.
 // Depending if the container is privileged and/or trusted,
 // this will return either the trusted or untrusted runtime path.
-func (r *Runtime) Path(c *Container) (string, error) {
+func (r *RuntimeBase) path(c *Container) (string, error) {
 	if c.runtimeHandler != "" {
 		runtimeHandler, err := r.ValidateRuntimeHandler(c.runtimeHandler)
 		if err != nil {
@@ -208,185 +235,6 @@ func (r *Runtime) Path(c *Container) (string, error) {
 	return r.untrustedPath, nil
 }
 
-// Version returns the version of the OCI Runtime
-func (r *Runtime) Version() (string, error) {
-	runtimeVersion, err := getOCIVersion(r.trustedPath, "-v")
-	if err != nil {
-		return "", err
-	}
-	return runtimeVersion, nil
-}
-
-func getOCIVersion(name string, args ...string) (string, error) {
-	out, err := utils.ExecCmd(name, args...)
-	if err != nil {
-		return "", err
-	}
-
-	firstLine := out[:strings.Index(out, "\n")]
-	v := firstLine[strings.LastIndex(firstLine, " ")+1:]
-	return v, nil
-}
-
-// CreateContainer creates a container.
-func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error) {
-	var stderrBuf bytes.Buffer
-	parentPipe, childPipe, err := newPipe()
-	childStartPipe, parentStartPipe, err := newPipe()
-	if err != nil {
-		return fmt.Errorf("error creating socket pair: %v", err)
-	}
-	defer parentPipe.Close()
-	defer parentStartPipe.Close()
-
-	var args []string
-	if r.cgroupManager == SystemdCgroupsManager {
-		args = append(args, "-s")
-	}
-	if r.cgroupManager == CgroupfsCgroupsManager {
-		args = append(args, "--syslog")
-	}
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	args = append(args, "-c", c.id)
-	args = append(args, "-u", c.id)
-	args = append(args, "-r", rPath)
-	args = append(args, "-b", c.bundlePath)
-	args = append(args, "-p", filepath.Join(c.bundlePath, "pidfile"))
-	args = append(args, "-l", c.logPath)
-	args = append(args, "--exit-dir", r.containerExitsDir)
-	args = append(args, "--socket-dir-path", r.containerAttachSocketDir)
-	args = append(args, "--log-level", logrus.GetLevel().String())
-	if r.logSizeMax >= 0 {
-		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
-	}
-	if r.noPivot {
-		args = append(args, "--no-pivot")
-	}
-	if c.terminal {
-		args = append(args, "-t")
-	} else if c.stdin {
-		if !c.stdinOnce {
-			args = append(args, "--leave-stdin-open")
-		}
-		args = append(args, "-i")
-	}
-	logrus.WithFields(logrus.Fields{
-		"args": args,
-	}).Debugf("running conmon: %s", r.conmonPath)
-
-	cmd := exec.Command(r.conmonPath, args...)
-	cmd.Dir = c.bundlePath
-	cmd.SysProcAttr = sysProcAttrPlatform()
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if c.terminal {
-		cmd.Stderr = &stderrBuf
-	}
-	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe, childStartPipe)
-	// 0, 1 and 2 are stdin, stdout and stderr
-	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", os.Getenv("XDG_RUNTIME_DIR")))
-
-	err = cmd.Start()
-	if err != nil {
-		childPipe.Close()
-		return err
-	}
-
-	// We don't need childPipe on the parent side
-	childPipe.Close()
-	childStartPipe.Close()
-
-	// Platform specific container setup
-	if err := r.createContainerPlatform(c, cgroupParent, cmd.Process.Pid); err != nil {
-		logrus.Warnf("%s", err)
-	}
-
-	/* We set the cgroup, now the child can start creating children */
-	someData := []byte{0}
-	_, err = parentStartPipe.Write(someData)
-	if err != nil {
-		cmd.Wait()
-		return err
-	}
-
-	/* Wait for initial setup and fork, and reap child */
-	err = cmd.Wait()
-	if err != nil {
-		return err
-	}
-
-	// We will delete all container resources if creation fails
-	defer func() {
-		if err != nil {
-			r.DeleteContainer(c)
-		}
-	}()
-
-	// Wait to get container pid from conmon
-	type syncStruct struct {
-		si  *syncInfo
-		err error
-	}
-	ch := make(chan syncStruct)
-	go func() {
-		var si *syncInfo
-		if err = json.NewDecoder(parentPipe).Decode(&si); err != nil {
-			ch <- syncStruct{err: err}
-			return
-		}
-		ch <- syncStruct{si: si}
-	}()
-
-	select {
-	case ss := <-ch:
-		if ss.err != nil {
-			return fmt.Errorf("error reading container (probably exited) json message: %v", ss.err)
-		}
-		logrus.Debugf("Received container pid: %d", ss.si.Pid)
-		if ss.si.Pid == -1 {
-			if ss.si.Message != "" {
-				logrus.Errorf("Container creation error: %s", ss.si.Message)
-				return fmt.Errorf("container create failed: %s", ss.si.Message)
-			}
-			logrus.Errorf("Container creation failed")
-			return fmt.Errorf("container create failed")
-		}
-	case <-time.After(ContainerCreateTimeout):
-		logrus.Errorf("Container creation timeout (%v)", ContainerCreateTimeout)
-		return fmt.Errorf("create container timeout")
-	}
-	return nil
-}
-
-func createUnitName(prefix string, name string) string {
-	return fmt.Sprintf("%s-%s.scope", prefix, name)
-}
-
-// StartContainer starts a container.
-func (r *Runtime) StartContainer(c *Container) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "start", c.id); err != nil {
-		return err
-	}
-	c.state.Started = time.Now()
-	return nil
-}
-
 // ExecSyncResponse is returned from ExecSync.
 type ExecSyncResponse struct {
 	Stdout   []byte
@@ -406,472 +254,8 @@ func (e ExecSyncError) Error() string {
 	return fmt.Sprintf("command error: %+v, stdout: %s, stderr: %s, exit code %d", e.Err, e.Stdout.Bytes(), e.Stderr.Bytes(), e.ExitCode)
 }
 
-func prepareExec() (pidFile, parentPipe, childPipe *os.File, err error) {
-	parentPipe, childPipe, err = os.Pipe()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	pidFile, err = ioutil.TempFile("", "pidfile")
-	if err != nil {
-		parentPipe.Close()
-		childPipe.Close()
-		return nil, nil, nil, err
-	}
-
-	return
-}
-
-func parseLog(log []byte) (stdout, stderr []byte) {
-	// Split the log on newlines, which is what separates entries.
-	lines := bytes.SplitAfter(log, []byte{'\n'})
-	for _, line := range lines {
-		// Ignore empty lines.
-		if len(line) == 0 {
-			continue
-		}
-
-		// The format of log lines is "DATE pipe LogTag REST".
-		parts := bytes.SplitN(line, []byte{' '}, 4)
-		if len(parts) < 4 {
-			// Ignore the line if it's formatted incorrectly, but complain
-			// about it so it can be debugged.
-			logrus.Warnf("hit invalid log format: %q", string(line))
-			continue
-		}
-
-		pipe := string(parts[1])
-		content := parts[3]
-
-		linetype := string(parts[2])
-		if linetype == "P" {
-			contentLen := len(content)
-			if content[contentLen-1] == '\n' {
-				content = content[:contentLen-1]
-			}
-		}
-
-		switch pipe {
-		case "stdout":
-			stdout = append(stdout, content...)
-		case "stderr":
-			stderr = append(stderr, content...)
-		default:
-			// Complain about unknown pipes.
-			logrus.Warnf("hit invalid log format [unknown pipe %s]: %q", pipe, string(line))
-			continue
-		}
-	}
-
-	return stdout, stderr
-}
-
-// Exec prepares a streaming endpoint to execute a command in the container.
-func (r *Runtime) Exec(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	processFile, err := prepareProcessExec(c, cmd, tty)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(processFile.Name())
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	args := []string{"exec"}
-	args = append(args, "--process", processFile.Name())
-	args = append(args, c.ID())
-	execCmd := exec.Command(rPath, args...)
-	var cmdErr error
-	if tty {
-		cmdErr = ttyCmd(execCmd, stdin, stdout, resize)
-	} else {
-		if stdin != nil {
-			// Use an os.Pipe here as it returns true *os.File objects.
-			// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
-			// the call below to execCmd.Run() can unblock because its Stdin is the read half
-			// of the pipe.
-			r, w, err := os.Pipe()
-			if err != nil {
-				return err
-			}
-			go pools.Copy(w, stdin)
-
-			execCmd.Stdin = r
-		}
-		if stdout != nil {
-			execCmd.Stdout = stdout
-		}
-		if stderr != nil {
-			execCmd.Stderr = stderr
-		}
-
-		cmdErr = execCmd.Run()
-	}
-
-	if exitErr, ok := cmdErr.(*exec.ExitError); ok {
-		return &utilexec.ExitErrorWrapper{ExitError: exitErr}
-	}
-	return cmdErr
-}
-
-// ExecSync execs a command in a container and returns it's stdout, stderr and return code.
-func (r *Runtime) ExecSync(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
-	pidFile, parentPipe, childPipe, err := prepareExec()
-	if err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-	defer parentPipe.Close()
-	defer func() {
-		if e := os.Remove(pidFile.Name()); e != nil {
-			logrus.Warnf("could not remove temporary PID file %s", pidFile.Name())
-		}
-	}()
-
-	logFile, err := ioutil.TempFile("", "crio-log-"+c.id)
-	if err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-	logPath := logFile.Name()
-	defer func() {
-		logFile.Close()
-		os.RemoveAll(logPath)
-	}()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-
-	var args []string
-	args = append(args, "-c", c.id)
-	args = append(args, "-r", rPath)
-	args = append(args, "-p", pidFile.Name())
-	args = append(args, "-e")
-	if c.terminal {
-		args = append(args, "-t")
-	}
-	if timeout > 0 {
-		args = append(args, "-T")
-		args = append(args, fmt.Sprintf("%d", timeout))
-	}
-	args = append(args, "-l", logPath)
-	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
-	args = append(args, "--log-level", logrus.GetLevel().String())
-
-	processFile, err := prepareProcessExec(c, command, c.terminal)
-	if err != nil {
-		return nil, ExecSyncError{
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-	defer os.RemoveAll(processFile.Name())
-
-	args = append(args, "--exec-process-spec", processFile.Name())
-
-	cmd := exec.Command(r.conmonPath, args...)
-
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe)
-	// 0, 1 and 2 are stdin, stdout and stderr
-	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
-
-	err = cmd.Start()
-	if err != nil {
-		childPipe.Close()
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-
-	// We don't need childPipe on the parent side
-	childPipe.Close()
-
-	err = cmd.Wait()
-	if err != nil {
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: getExitCode(err),
-			Err:      err,
-		}
-	}
-
-	var ec *exitCodeInfo
-	if err := json.NewDecoder(parentPipe).Decode(&ec); err != nil {
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-
-	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
-
-	if ec.ExitCode == -1 {
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: -1,
-			Err:      fmt.Errorf(ec.Message),
-		}
-	}
-
-	// The actual logged output is not the same as stdoutBuf and stderrBuf,
-	// which are used for getting error information. For the actual
-	// ExecSyncResponse we have to read the logfile.
-	// XXX: Currently runC dups the same console over both stdout and stderr,
-	//      so we can't differentiate between the two.
-
-	logBytes, err := ioutil.ReadFile(logPath)
-	if err != nil {
-		return nil, ExecSyncError{
-			Stdout:   stdoutBuf,
-			Stderr:   stderrBuf,
-			ExitCode: -1,
-			Err:      err,
-		}
-	}
-
-	// We have to parse the log output into {stdout, stderr} buffers.
-	stdoutBytes, stderrBytes := parseLog(logBytes)
-	return &ExecSyncResponse{
-		Stdout:   stdoutBytes,
-		Stderr:   stderrBytes,
-		ExitCode: ec.ExitCode,
-	}, nil
-}
-
-// UpdateContainer updates container resources
-func (r *Runtime) UpdateContainer(c *Container, res *rspec.LinuxResources) error {
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command(rPath, "update", "--resources", "-", c.id)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	jsonResources, err := json.Marshal(res)
-	if err != nil {
-		return err
-	}
-	cmd.Stdin = bytes.NewReader(jsonResources)
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("updating resources for container %q failed: %v %v (%v)", c.id, stderr.String(), stdout.String(), err)
-	}
-	return nil
-}
-
-func waitContainerStop(ctx context.Context, c *Container, timeout time.Duration, ignoreKill bool) error {
-	done := make(chan struct{})
-	// we could potentially re-use "done" channel to exit the loop on timeout,
-	// but we use another channel "chControl" so that we never panic
-	// attempting to close an already-closed "done" channel.  The panic
-	// would occur in the "default" select case below if we'd closed the
-	// "done" channel (instead of the "chControl" channel) in the timeout
-	// select case.
-	chControl := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-chControl:
-				return
-			default:
-				process, err := findprocess.FindProcess(c.state.Pid)
-				if err != nil {
-					if err != findprocess.ErrNotFound {
-						logrus.Warnf("failed to find process %d for container %q: %v", c.state.Pid, c.id, err)
-					}
-					close(done)
-					return
-				}
-				err = process.Release()
-				if err != nil {
-					logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
-		}
-	}()
-	select {
-	case <-done:
-		return nil
-	case <-ctx.Done():
-		close(chControl)
-		return ctx.Err()
-	case <-time.After(timeout):
-		close(chControl)
-		if ignoreKill {
-			return fmt.Errorf("failed to wait process, timeout reached after %.0f seconds",
-				timeout.Seconds())
-		}
-		err := kill(c.state.Pid)
-		if err != nil {
-			return fmt.Errorf("failed to kill process: %v", err)
-		}
-	}
-
-	c.state.Finished = time.Now()
-	return nil
-}
-
-// WaitContainerStateStopped runs a loop polling UpdateStatus(), seeking for
-// the container status to be updated to 'stopped'. Either it gets the expected
-// status and returns nil, or it reaches the timeout and returns an error.
-func (r *Runtime) WaitContainerStateStopped(ctx context.Context, c *Container) (err error) {
-	// No need to go further and spawn the go routine if the container
-	// is already in the expected status.
-	if r.ContainerStatus(c).Status == ContainerStateStopped {
-		return nil
-	}
-
-	// We need to ensure the container termination will be properly waited
-	// for by defining a minimal timeout value. This will prevent timeout
-	// value defined in the configuration file to be too low.
-	timeout := r.ctrStopTimeout
-	if timeout < minCtrStopTimeout {
-		timeout = minCtrStopTimeout
-	}
-
-	done := make(chan error)
-	chControl := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-chControl:
-				return
-			default:
-				// Check if the container is stopped
-				if err := r.UpdateStatus(c); err != nil {
-					done <- err
-					close(done)
-					return
-				}
-				if r.ContainerStatus(c).Status == ContainerStateStopped {
-					close(done)
-					return
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
-		}
-	}()
-	select {
-	case err = <-done:
-		break
-	case <-ctx.Done():
-		close(chControl)
-		return ctx.Err()
-	case <-time.After(time.Duration(timeout) * time.Second):
-		close(chControl)
-		return fmt.Errorf("failed to get container stopped status: %ds timeout reached", timeout)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to get container stopped status: %v", err)
-	}
-
-	return nil
-}
-
-// StopContainer stops a container. Timeout is given in seconds.
-func (r *Runtime) StopContainer(ctx context.Context, c *Container, timeout int64) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	// Check if the process is around before sending a signal
-	process, err := findprocess.FindProcess(c.state.Pid)
-	if err == findprocess.ErrNotFound {
-		c.state.Finished = time.Now()
-		return nil
-	}
-	if err != nil {
-		logrus.Warnf("failed to find process %d for container %q: %v", c.state.Pid, c.id, err)
-	} else {
-		err = process.Release()
-		if err != nil {
-			logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
-		}
-	}
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	if timeout > 0 {
-		if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.id, c.GetStopSignal()); err != nil {
-			if err := checkProcessGone(c); err != nil {
-				return fmt.Errorf("failed to stop container %q: %v", c.id, err)
-			}
-		}
-		err = waitContainerStop(ctx, c, time.Duration(timeout)*time.Second, true)
-		if err == nil {
-			return nil
-		}
-		logrus.Warnf("Stop container %q timed out: %v", c.id, err)
-	}
-
-	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.id, "KILL"); err != nil {
-		if err := checkProcessGone(c); err != nil {
-			return fmt.Errorf("failed to stop container %q: %v", c.id, err)
-		}
-	}
-
-	return waitContainerStop(ctx, c, killContainerTimeout, false)
-}
-
-func checkProcessGone(c *Container) error {
-	process, perr := findprocess.FindProcess(c.state.Pid)
-	if perr == findprocess.ErrNotFound {
-		c.state.Finished = time.Now()
-		return nil
-	}
-	if perr == nil {
-		err := process.Release()
-		if err != nil {
-			logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
-		}
-	}
-	return fmt.Errorf("failed to find process: %v", perr)
-}
-
-// DeleteContainer deletes a container.
-func (r *Runtime) DeleteContainer(c *Container) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	_, err = utils.ExecCmd(rPath, "delete", "--force", c.id)
-	return err
-}
-
 // SetStartFailed sets the container state appropriately after a start failure
-func (r *Runtime) SetStartFailed(c *Container, err error) {
+func (r *RuntimeBase) SetStartFailed(c *Container, err error) {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	// adjust finished and started times
@@ -879,326 +263,14 @@ func (r *Runtime) SetStartFailed(c *Container, err error) {
 	c.state.Error = err.Error()
 }
 
-// UpdateStatus refreshes the status of the container.
-func (r *Runtime) UpdateStatus(c *Container) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	out, err := exec.Command(rPath, "state", c.id).Output()
-	if err != nil {
-		// there are many code paths that could lead to have a bad state in the
-		// underlying runtime.
-		// On any error like a container went away or we rebooted and containers
-		// went away we do not error out stopping kubernetes to recover.
-		// We always populate the fields below so kube can restart/reschedule
-		// containers failing.
-		c.state.Status = ContainerStateStopped
-		c.state.Finished = time.Now()
-		c.state.ExitCode = 255
-		return nil
-	}
-	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(&c.state); err != nil {
-		return fmt.Errorf("failed to decode container status for %s: %s", c.id, err)
-	}
-
-	if c.state.Status == ContainerStateStopped {
-		exitFilePath := filepath.Join(r.containerExitsDir, c.id)
-		var fi os.FileInfo
-		err = kwait.ExponentialBackoff(
-			kwait.Backoff{
-				Duration: 500 * time.Millisecond,
-				Factor:   1.2,
-				Steps:    6,
-			},
-			func() (bool, error) {
-				var err error
-				fi, err = os.Stat(exitFilePath)
-				if err != nil {
-					// wait longer
-					return false, nil
-				}
-				return true, nil
-			})
-		if err != nil {
-			logrus.Warnf("failed to find container exit file for %v: %v", c.id, err)
-			c.state.ExitCode = -1
-		} else {
-			c.state.Finished = getFinishedTime(fi)
-			statusCodeStr, err := ioutil.ReadFile(exitFilePath)
-			if err != nil {
-				return fmt.Errorf("failed to read exit file: %v", err)
-			}
-			statusCode, err := strconv.Atoi(string(statusCodeStr))
-			if err != nil {
-				return fmt.Errorf("status code conversion failed: %v", err)
-			}
-			c.state.ExitCode = int32(statusCode)
-		}
-
-		oomFilePath := filepath.Join(c.bundlePath, "oom")
-		if _, err = os.Stat(oomFilePath); err == nil {
-			c.state.OOMKilled = true
-		}
-	}
-
-	return nil
-}
-
 // ContainerStatus returns the state of a container.
-func (r *Runtime) ContainerStatus(c *Container) *ContainerState {
+func (r *RuntimeBase) ContainerStatus(c *Container) *ContainerState {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 	return c.state
 }
 
 // CurrentContainerStatus returns the state of a container without using a lock.
-func (r *Runtime) CurrentContainerStatus(c *Container) *ContainerState {
+func (r *RuntimeBase) CurrentContainerStatus(c *Container) *ContainerState {
 	return c.state
-}
-
-// PauseContainer pauses a container.
-func (r *Runtime) PauseContainer(c *Container) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	_, err = utils.ExecCmd(rPath, "pause", c.id)
-	return err
-}
-
-// UnpauseContainer unpauses a container.
-func (r *Runtime) UnpauseContainer(c *Container) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	_, err = utils.ExecCmd(rPath, "resume", c.id)
-	return err
-}
-
-// ContainerStats provides statistics of a container.
-func (r *Runtime) ContainerStats(c *Container) (*ContainerStats, error) {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	return containerStats(c)
-}
-
-// SignalContainer sends a signal to a container process.
-func (r *Runtime) SignalContainer(c *Container, sig syscall.Signal) error {
-	c.opLock.Lock()
-	defer c.opLock.Unlock()
-
-	signalString, err := findStringInSignalMap(sig)
-	if err != nil {
-		return err
-	}
-
-	rPath, err := r.Path(c)
-	if err != nil {
-		return err
-	}
-
-	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.ID(), signalString)
-}
-
-// AttachContainer attaches IO to a running container.
-func (r *Runtime) AttachContainer(c *Container, inputStream io.Reader, outputStream, errorStream io.Writer, tty bool, resize <-chan remotecommand.TerminalSize) error {
-	controlPath := filepath.Join(c.BundlePath(), "ctl")
-	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open container ctl file: %v", err)
-	}
-	defer controlFile.Close()
-
-	kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
-		logrus.Debugf("Got a resize event: %+v", size)
-		_, err := fmt.Fprintf(controlFile, "%d %d %d\n", 1, size.Height, size.Width)
-		if err != nil {
-			logrus.Debugf("Failed to write to control file to resize terminal: %v", err)
-		}
-	})
-
-	attachSocketPath := filepath.Join(r.containerAttachSocketDir, c.ID(), "attach")
-	conn, err := net.DialUnix("unixpacket", nil, &net.UnixAddr{Name: attachSocketPath, Net: "unixpacket"})
-	if err != nil {
-		return fmt.Errorf("failed to connect to container %s attach socket: %v", c.ID(), err)
-	}
-	defer conn.Close()
-
-	receiveStdout := make(chan error)
-	if outputStream != nil || errorStream != nil {
-		go func() {
-			receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
-		}()
-	}
-
-	stdinDone := make(chan error)
-	go func() {
-		var err error
-		if inputStream != nil {
-			_, err = utils.CopyDetachable(conn, inputStream, nil)
-			conn.CloseWrite()
-		}
-		stdinDone <- err
-	}()
-
-	select {
-	case err := <-receiveStdout:
-		return err
-	case err := <-stdinDone:
-		if _, ok := err.(utils.DetachError); ok {
-			return nil
-		}
-		if outputStream != nil || errorStream != nil {
-			return <-receiveStdout
-		}
-	}
-
-	return nil
-}
-
-// PortForwardContainer forwards the specified port provides statistics of a container.
-func (r *Runtime) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
-	containerPid := c.State().Pid
-	socatPath, lookupErr := exec.LookPath("socat")
-	if lookupErr != nil {
-		return fmt.Errorf("unable to do port forwarding: socat not found")
-	}
-
-	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
-
-	nsenterPath, lookupErr := exec.LookPath("nsenter")
-	if lookupErr != nil {
-		return fmt.Errorf("unable to do port forwarding: nsenter not found")
-	}
-
-	commandString := fmt.Sprintf("%s %s", nsenterPath, strings.Join(args, " "))
-	logrus.Debugf("executing port forwarding command: %s", commandString)
-
-	command := exec.Command(nsenterPath, args...)
-	command.Stdout = stream
-
-	stderr := new(bytes.Buffer)
-	command.Stderr = stderr
-
-	// If we use Stdin, command.Run() won't return until the goroutine that's copying
-	// from stream finishes. Unfortunately, if you have a client like telnet connected
-	// via port forwarding, as long as the user's telnet client is connected to the user's
-	// local listener that port forwarding sets up, the telnet session never exits. This
-	// means that even if socat has finished running, command.Run() won't ever return
-	// (because the client still has the connection and stream open).
-	//
-	// The work around is to use StdinPipe(), as Wait() (called by Run()) closes the pipe
-	// when the command (socat) exits.
-	inPipe, err := command.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("unable to do port forwarding: error creating stdin pipe: %v", err)
-	}
-	go func() {
-		pools.Copy(inPipe, stream)
-		inPipe.Close()
-	}()
-
-	if err := command.Run(); err != nil {
-		return fmt.Errorf("%v: %s", err, stderr.String())
-	}
-
-	return nil
-}
-
-// ReopenContainerLog reopens the log file of a container.
-func (r *Runtime) ReopenContainerLog(c *Container) error {
-	controlPath := filepath.Join(c.BundlePath(), "ctl")
-	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open container ctl file: %v", err)
-	}
-	defer controlFile.Close()
-
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return fmt.Errorf("Failed to create new watch: %v", err)
-	}
-	defer watcher.Close()
-
-	done := make(chan struct{})
-	errorCh := make(chan error)
-	go func() {
-		for {
-			select {
-			case event := <-watcher.Events:
-				logrus.Debugf("event: %v", event)
-				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
-					logrus.Debugf("file created %s", event.Name)
-					if event.Name == c.LogPath() {
-						logrus.Debugf("expected log file created")
-						close(done)
-						return
-					}
-				}
-			case err := <-watcher.Errors:
-				errorCh <- fmt.Errorf("watch error for container log reopen %v: %v", c.ID(), err)
-				return
-			}
-		}
-	}()
-	cLogDir := filepath.Dir(c.LogPath())
-	if err := watcher.Add(cLogDir); err != nil {
-		logrus.Errorf("watcher.Add(%q) failed: %s", cLogDir, err)
-		close(done)
-	}
-
-	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
-		logrus.Debugf("Failed to write to control file to reopen log file: %v", err)
-	}
-
-	select {
-	case err := <-errorCh:
-		return err
-	case <-done:
-		break
-	}
-
-	return nil
-}
-
-// prepareProcessExec returns the path of the process.json used in runc exec -p
-// caller is responsible to close the returned *os.File if needed.
-func prepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) {
-	f, err := ioutil.TempFile("", "exec-process-")
-	if err != nil {
-		return nil, err
-	}
-
-	pspec := c.Spec().Process
-	pspec.Args = cmd
-	// We need to default this to false else it will inherit terminal as true
-	// from the container.
-	pspec.Terminal = false
-	if tty {
-		pspec.Terminal = true
-	}
-	processJSON, err := json.Marshal(pspec)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
-		return nil, err
-	}
-	return f, nil
 }

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -84,14 +84,14 @@ type RuntimeImpl interface {
 	Version() (string, error)
 	CreateContainer(*Container, string) error
 	StartContainer(*Container) error
-	Exec(*Container, []string, io.Reader, io.WriteCloser, io.WriteCloser,
+	ExecContainer(*Container, []string, io.Reader, io.WriteCloser, io.WriteCloser,
 		bool, <-chan remotecommand.TerminalSize) error
-	ExecSync(*Container, []string, int64) (*ExecSyncResponse, error)
+	ExecSyncContainer(*Container, []string, int64) (*ExecSyncResponse, error)
 	UpdateContainer(*Container, *rspec.LinuxResources) error
 	WaitContainerStateStopped(context.Context, *Container) error
 	StopContainer(context.Context, *Container, int64) error
 	DeleteContainer(*Container) error
-	UpdateStatus(*Container) error
+	UpdateContainerStatus(*Container) error
 	PauseContainer(*Container) error
 	UnpauseContainer(*Container) error
 	ContainerStats(*Container) (*ContainerStats, error)

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -3,6 +3,7 @@
 package oci
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -16,7 +17,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (r *Runtime) createContainerPlatform(c *Container, cgroupParent string, pid int) error {
+func createUnitName(prefix string, name string) string {
+	return fmt.Sprintf("%s-%s.scope", prefix, name)
+}
+
+func (r *RuntimeV1) createContainerPlatform(c *Container, cgroupParent string, pid int) error {
 	// Move conmon to specified cgroup
 	if r.cgroupManager == SystemdCgroupsManager {
 		logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, createUnitName("crio-conmon", c.id))

--- a/oci/runtime_v1.go
+++ b/oci/runtime_v1.go
@@ -289,8 +289,8 @@ func parseLog(log []byte) (stdout, stderr []byte) {
 	return stdout, stderr
 }
 
-// Exec prepares a streaming endpoint to execute a command in the container.
-func (r *RuntimeV1) Exec(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+// ExecContainer prepares a streaming endpoint to execute a command in the container.
+func (r *RuntimeV1) ExecContainer(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
 	processFile, err := prepareProcessExec(c, cmd, tty)
 	if err != nil {
 		return err
@@ -339,8 +339,8 @@ func (r *RuntimeV1) Exec(c *Container, cmd []string, stdin io.Reader, stdout, st
 	return cmdErr
 }
 
-// ExecSync execs a command in a container and returns it's stdout, stderr and return code.
-func (r *RuntimeV1) ExecSync(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
+// ExecSyncContainer execs a command in a container and returns it's stdout, stderr and return code.
+func (r *RuntimeV1) ExecSyncContainer(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
 	pidFile, parentPipe, childPipe, err := prepareExec()
 	if err != nil {
 		return nil, ExecSyncError{
@@ -586,7 +586,7 @@ func (r *RuntimeV1) WaitContainerStateStopped(ctx context.Context, c *Container)
 				return
 			default:
 				// Check if the container is stopped
-				if err := r.UpdateStatus(c); err != nil {
+				if err := r.UpdateContainerStatus(c); err != nil {
 					done <- err
 					close(done)
 					return
@@ -693,8 +693,8 @@ func (r *RuntimeV1) DeleteContainer(c *Container) error {
 	return err
 }
 
-// UpdateStatus refreshes the status of the container.
-func (r *RuntimeV1) UpdateStatus(c *Container) error {
+// UpdateContainerStatus refreshes the status of the container.
+func (r *RuntimeV1) UpdateContainerStatus(c *Container) error {
 	c.opLock.Lock()
 	defer c.opLock.Unlock()
 

--- a/oci/runtime_v1.go
+++ b/oci/runtime_v1.go
@@ -565,7 +565,7 @@ func waitContainerStop(ctx context.Context, c *Container, timeout time.Duration,
 func (r *RuntimeV1) WaitContainerStateStopped(ctx context.Context, c *Container) (err error) {
 	// No need to go further and spawn the go routine if the container
 	// is already in the expected status.
-	if r.ContainerStatus(c).Status == ContainerStateStopped {
+	if c.State().Status == ContainerStateStopped {
 		return nil
 	}
 
@@ -591,7 +591,7 @@ func (r *RuntimeV1) WaitContainerStateStopped(ctx context.Context, c *Container)
 					close(done)
 					return
 				}
-				if r.ContainerStatus(c).Status == ContainerStateStopped {
+				if c.State().Status == ContainerStateStopped {
 					close(done)
 					return
 				}

--- a/oci/runtime_v1.go
+++ b/oci/runtime_v1.go
@@ -1,0 +1,1006 @@
+package oci
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/docker/docker/pkg/pools"
+	"github.com/fsnotify/fsnotify"
+	"github.com/kubernetes-sigs/cri-o/pkg/findprocess"
+	"github.com/kubernetes-sigs/cri-o/utils"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/remotecommand"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	utilexec "k8s.io/utils/exec"
+)
+
+// RuntimeV1 is the Runtime interface implementation relying on conmon to
+// interact with the container runtime.
+type RuntimeV1 struct {
+	RuntimeBase
+}
+
+// NewRuntimeV1 creates a new RuntimeV1 instance
+func NewRuntimeV1(rb RuntimeBase) (RuntimeImpl, error) {
+	return &RuntimeV1{
+		RuntimeBase: rb,
+	}, nil
+}
+
+// syncInfo is used to return data from monitor process to daemon
+type syncInfo struct {
+	Pid     int    `json:"pid"`
+	Message string `json:"message,omitempty"`
+}
+
+// exitCodeInfo is used to return the monitored process exit code to the daemon
+type exitCodeInfo struct {
+	ExitCode int32  `json:"exit_code"`
+	Message  string `json:"message,omitempty"`
+}
+
+// Version returns the version of the OCI Runtime
+// Version returns the version of the OCI Runtime
+func (r *RuntimeV1) Version() (string, error) {
+	runtimeVersion, err := getOCIVersion(r.trustedPath, "-v")
+	if err != nil {
+		return "", err
+	}
+	return runtimeVersion, nil
+}
+
+func getOCIVersion(name string, args ...string) (string, error) {
+	out, err := utils.ExecCmd(name, args...)
+	if err != nil {
+		return "", err
+	}
+
+	firstLine := out[:strings.Index(out, "\n")]
+	v := firstLine[strings.LastIndex(firstLine, " ")+1:]
+	return v, nil
+}
+
+// CreateContainer creates a container.
+func (r *RuntimeV1) CreateContainer(c *Container, cgroupParent string) (err error) {
+	var stderrBuf bytes.Buffer
+	parentPipe, childPipe, err := newPipe()
+	childStartPipe, parentStartPipe, err := newPipe()
+	if err != nil {
+		return fmt.Errorf("error creating socket pair: %v", err)
+	}
+	defer parentPipe.Close()
+	defer parentStartPipe.Close()
+
+	var args []string
+	if r.cgroupManager == SystemdCgroupsManager {
+		args = append(args, "-s")
+	}
+	if r.cgroupManager == CgroupfsCgroupsManager {
+		args = append(args, "--syslog")
+	}
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	args = append(args, "-c", c.id)
+	args = append(args, "-u", c.id)
+	args = append(args, "-r", rPath)
+	args = append(args, "-b", c.bundlePath)
+	args = append(args, "-p", filepath.Join(c.bundlePath, "pidfile"))
+	args = append(args, "-l", c.logPath)
+	args = append(args, "--exit-dir", r.containerExitsDir)
+	args = append(args, "--socket-dir-path", r.containerAttachSocketDir)
+	args = append(args, "--log-level", logrus.GetLevel().String())
+	if r.logSizeMax >= 0 {
+		args = append(args, "--log-size-max", fmt.Sprintf("%v", r.logSizeMax))
+	}
+	if r.noPivot {
+		args = append(args, "--no-pivot")
+	}
+	if c.terminal {
+		args = append(args, "-t")
+	} else if c.stdin {
+		if !c.stdinOnce {
+			args = append(args, "--leave-stdin-open")
+		}
+		args = append(args, "-i")
+	}
+	logrus.WithFields(logrus.Fields{
+		"args": args,
+	}).Debugf("running conmon: %s", r.conmonPath)
+
+	cmd := exec.Command(r.conmonPath, args...)
+	cmd.Dir = c.bundlePath
+	cmd.SysProcAttr = sysProcAttrPlatform()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if c.terminal {
+		cmd.Stderr = &stderrBuf
+	}
+	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe, childStartPipe)
+	// 0, 1 and 2 are stdin, stdout and stderr
+	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("_OCI_STARTPIPE=%d", 4))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("XDG_RUNTIME_DIR=%s", os.Getenv("XDG_RUNTIME_DIR")))
+
+	err = cmd.Start()
+	if err != nil {
+		childPipe.Close()
+		return err
+	}
+
+	// We don't need childPipe on the parent side
+	childPipe.Close()
+	childStartPipe.Close()
+
+	// Platform specific container setup
+	if err := r.createContainerPlatform(c, cgroupParent, cmd.Process.Pid); err != nil {
+		logrus.Warnf("%s", err)
+	}
+
+	/* We set the cgroup, now the child can start creating children */
+	someData := []byte{0}
+	_, err = parentStartPipe.Write(someData)
+	if err != nil {
+		cmd.Wait()
+		return err
+	}
+
+	/* Wait for initial setup and fork, and reap child */
+	err = cmd.Wait()
+	if err != nil {
+		return err
+	}
+
+	// We will delete all container resources if creation fails
+	defer func() {
+		if err != nil {
+			r.DeleteContainer(c)
+		}
+	}()
+
+	// Wait to get container pid from conmon
+	type syncStruct struct {
+		si  *syncInfo
+		err error
+	}
+	ch := make(chan syncStruct)
+	go func() {
+		var si *syncInfo
+		if err = json.NewDecoder(parentPipe).Decode(&si); err != nil {
+			ch <- syncStruct{err: err}
+			return
+		}
+		ch <- syncStruct{si: si}
+	}()
+
+	select {
+	case ss := <-ch:
+		if ss.err != nil {
+			return fmt.Errorf("error reading container (probably exited) json message: %v", ss.err)
+		}
+		logrus.Debugf("Received container pid: %d", ss.si.Pid)
+		if ss.si.Pid == -1 {
+			if ss.si.Message != "" {
+				logrus.Errorf("Container creation error: %s", ss.si.Message)
+				return fmt.Errorf("container create failed: %s", ss.si.Message)
+			}
+			logrus.Errorf("Container creation failed")
+			return fmt.Errorf("container create failed")
+		}
+	case <-time.After(ContainerCreateTimeout):
+		logrus.Errorf("Container creation timeout (%v)", ContainerCreateTimeout)
+		return fmt.Errorf("create container timeout")
+	}
+	return nil
+}
+
+// StartContainer starts a container.
+func (r *RuntimeV1) StartContainer(c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "start", c.id); err != nil {
+		return err
+	}
+	c.state.Started = time.Now()
+	return nil
+}
+
+func prepareExec() (pidFile, parentPipe, childPipe *os.File, err error) {
+	parentPipe, childPipe, err = os.Pipe()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pidFile, err = ioutil.TempFile("", "pidfile")
+	if err != nil {
+		parentPipe.Close()
+		childPipe.Close()
+		return nil, nil, nil, err
+	}
+
+	return
+}
+
+func parseLog(log []byte) (stdout, stderr []byte) {
+	// Split the log on newlines, which is what separates entries.
+	lines := bytes.SplitAfter(log, []byte{'\n'})
+	for _, line := range lines {
+		// Ignore empty lines.
+		if len(line) == 0 {
+			continue
+		}
+
+		// The format of log lines is "DATE pipe LogTag REST".
+		parts := bytes.SplitN(line, []byte{' '}, 4)
+		if len(parts) < 4 {
+			// Ignore the line if it's formatted incorrectly, but complain
+			// about it so it can be debugged.
+			logrus.Warnf("hit invalid log format: %q", string(line))
+			continue
+		}
+
+		pipe := string(parts[1])
+		content := parts[3]
+
+		linetype := string(parts[2])
+		if linetype == "P" {
+			contentLen := len(content)
+			if content[contentLen-1] == '\n' {
+				content = content[:contentLen-1]
+			}
+		}
+
+		switch pipe {
+		case "stdout":
+			stdout = append(stdout, content...)
+		case "stderr":
+			stderr = append(stderr, content...)
+		default:
+			// Complain about unknown pipes.
+			logrus.Warnf("hit invalid log format [unknown pipe %s]: %q", pipe, string(line))
+			continue
+		}
+	}
+
+	return stdout, stderr
+}
+
+// Exec prepares a streaming endpoint to execute a command in the container.
+func (r *RuntimeV1) Exec(c *Container, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	processFile, err := prepareProcessExec(c, cmd, tty)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(processFile.Name())
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"exec"}
+	args = append(args, "--process", processFile.Name())
+	args = append(args, c.ID())
+	execCmd := exec.Command(rPath, args...)
+	var cmdErr error
+	if tty {
+		cmdErr = ttyCmd(execCmd, stdin, stdout, resize)
+	} else {
+		if stdin != nil {
+			// Use an os.Pipe here as it returns true *os.File objects.
+			// This way, if you run 'kubectl exec <pod> -i bash' (no tty) and type 'exit',
+			// the call below to execCmd.Run() can unblock because its Stdin is the read half
+			// of the pipe.
+			r, w, err := os.Pipe()
+			if err != nil {
+				return err
+			}
+			go pools.Copy(w, stdin)
+
+			execCmd.Stdin = r
+		}
+		if stdout != nil {
+			execCmd.Stdout = stdout
+		}
+		if stderr != nil {
+			execCmd.Stderr = stderr
+		}
+
+		cmdErr = execCmd.Run()
+	}
+
+	if exitErr, ok := cmdErr.(*exec.ExitError); ok {
+		return &utilexec.ExitErrorWrapper{ExitError: exitErr}
+	}
+	return cmdErr
+}
+
+// ExecSync execs a command in a container and returns it's stdout, stderr and return code.
+func (r *RuntimeV1) ExecSync(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
+	pidFile, parentPipe, childPipe, err := prepareExec()
+	if err != nil {
+		return nil, ExecSyncError{
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+	defer parentPipe.Close()
+	defer func() {
+		if e := os.Remove(pidFile.Name()); e != nil {
+			logrus.Warnf("could not remove temporary PID file %s", pidFile.Name())
+		}
+	}()
+
+	logFile, err := ioutil.TempFile("", "crio-log-"+c.id)
+	if err != nil {
+		return nil, ExecSyncError{
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+	logPath := logFile.Name()
+	defer func() {
+		logFile.Close()
+		os.RemoveAll(logPath)
+	}()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return nil, ExecSyncError{
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+
+	var args []string
+	args = append(args, "-c", c.id)
+	args = append(args, "-r", rPath)
+	args = append(args, "-p", pidFile.Name())
+	args = append(args, "-e")
+	if c.terminal {
+		args = append(args, "-t")
+	}
+	if timeout > 0 {
+		args = append(args, "-T")
+		args = append(args, fmt.Sprintf("%d", timeout))
+	}
+	args = append(args, "-l", logPath)
+	args = append(args, "--socket-dir-path", ContainerAttachSocketDir)
+	args = append(args, "--log-level", logrus.GetLevel().String())
+
+	processFile, err := prepareProcessExec(c, command, c.terminal)
+	if err != nil {
+		return nil, ExecSyncError{
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+	defer os.RemoveAll(processFile.Name())
+
+	args = append(args, "--exec-process-spec", processFile.Name())
+
+	cmd := exec.Command(r.conmonPath, args...)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	cmd.ExtraFiles = append(cmd.ExtraFiles, childPipe)
+	// 0, 1 and 2 are stdin, stdout and stderr
+	cmd.Env = append(r.conmonEnv, fmt.Sprintf("_OCI_SYNCPIPE=%d", 3))
+
+	err = cmd.Start()
+	if err != nil {
+		childPipe.Close()
+		return nil, ExecSyncError{
+			Stdout:   stdoutBuf,
+			Stderr:   stderrBuf,
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+
+	// We don't need childPipe on the parent side
+	childPipe.Close()
+
+	err = cmd.Wait()
+	if err != nil {
+		return nil, ExecSyncError{
+			Stdout:   stdoutBuf,
+			Stderr:   stderrBuf,
+			ExitCode: getExitCode(err),
+			Err:      err,
+		}
+	}
+
+	var ec *exitCodeInfo
+	if err := json.NewDecoder(parentPipe).Decode(&ec); err != nil {
+		return nil, ExecSyncError{
+			Stdout:   stdoutBuf,
+			Stderr:   stderrBuf,
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+
+	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
+
+	if ec.ExitCode == -1 {
+		return nil, ExecSyncError{
+			Stdout:   stdoutBuf,
+			Stderr:   stderrBuf,
+			ExitCode: -1,
+			Err:      fmt.Errorf(ec.Message),
+		}
+	}
+
+	// The actual logged output is not the same as stdoutBuf and stderrBuf,
+	// which are used for getting error information. For the actual
+	// ExecSyncResponse we have to read the logfile.
+	// XXX: Currently runC dups the same console over both stdout and stderr,
+	//      so we can't differentiate between the two.
+
+	logBytes, err := ioutil.ReadFile(logPath)
+	if err != nil {
+		return nil, ExecSyncError{
+			Stdout:   stdoutBuf,
+			Stderr:   stderrBuf,
+			ExitCode: -1,
+			Err:      err,
+		}
+	}
+
+	// We have to parse the log output into {stdout, stderr} buffers.
+	stdoutBytes, stderrBytes := parseLog(logBytes)
+	return &ExecSyncResponse{
+		Stdout:   stdoutBytes,
+		Stderr:   stderrBytes,
+		ExitCode: ec.ExitCode,
+	}, nil
+}
+
+// UpdateContainer updates container resources
+func (r *RuntimeV1) UpdateContainer(c *Container, res *rspec.LinuxResources) error {
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(rPath, "update", "--resources", "-", c.id)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	jsonResources, err := json.Marshal(res)
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = bytes.NewReader(jsonResources)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("updating resources for container %q failed: %v %v (%v)", c.id, stderr.String(), stdout.String(), err)
+	}
+	return nil
+}
+
+func waitContainerStop(ctx context.Context, c *Container, timeout time.Duration, ignoreKill bool) error {
+	done := make(chan struct{})
+	// we could potentially re-use "done" channel to exit the loop on timeout,
+	// but we use another channel "chControl" so that we never panic
+	// attempting to close an already-closed "done" channel.  The panic
+	// would occur in the "default" select case below if we'd closed the
+	// "done" channel (instead of the "chControl" channel) in the timeout
+	// select case.
+	chControl := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-chControl:
+				return
+			default:
+				process, err := findprocess.FindProcess(c.state.Pid)
+				if err != nil {
+					if err != findprocess.ErrNotFound {
+						logrus.Warnf("failed to find process %d for container %q: %v", c.state.Pid, c.id, err)
+					}
+					close(done)
+					return
+				}
+				err = process.Release()
+				if err != nil {
+					logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		close(chControl)
+		return ctx.Err()
+	case <-time.After(timeout):
+		close(chControl)
+		if ignoreKill {
+			return fmt.Errorf("failed to wait process, timeout reached after %.0f seconds",
+				timeout.Seconds())
+		}
+		err := kill(c.state.Pid)
+		if err != nil {
+			return fmt.Errorf("failed to kill process: %v", err)
+		}
+	}
+
+	c.state.Finished = time.Now()
+	return nil
+}
+
+// WaitContainerStateStopped runs a loop polling UpdateStatus(), seeking for
+// the container status to be updated to 'stopped'. Either it gets the expected
+// status and returns nil, or it reaches the timeout and returns an error.
+func (r *RuntimeV1) WaitContainerStateStopped(ctx context.Context, c *Container) (err error) {
+	// No need to go further and spawn the go routine if the container
+	// is already in the expected status.
+	if r.ContainerStatus(c).Status == ContainerStateStopped {
+		return nil
+	}
+
+	// We need to ensure the container termination will be properly waited
+	// for by defining a minimal timeout value. This will prevent timeout
+	// value defined in the configuration file to be too low.
+	timeout := r.ctrStopTimeout
+	if timeout < minCtrStopTimeout {
+		timeout = minCtrStopTimeout
+	}
+
+	done := make(chan error)
+	chControl := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-chControl:
+				return
+			default:
+				// Check if the container is stopped
+				if err := r.UpdateStatus(c); err != nil {
+					done <- err
+					close(done)
+					return
+				}
+				if r.ContainerStatus(c).Status == ContainerStateStopped {
+					close(done)
+					return
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+	select {
+	case err = <-done:
+		break
+	case <-ctx.Done():
+		close(chControl)
+		return ctx.Err()
+	case <-time.After(time.Duration(timeout) * time.Second):
+		close(chControl)
+		return fmt.Errorf("failed to get container stopped status: %ds timeout reached", timeout)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to get container stopped status: %v", err)
+	}
+
+	return nil
+}
+
+// StopContainer stops a container. Timeout is given in seconds.
+func (r *RuntimeV1) StopContainer(ctx context.Context, c *Container, timeout int64) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	// Check if the process is around before sending a signal
+	process, err := findprocess.FindProcess(c.state.Pid)
+	if err == findprocess.ErrNotFound {
+		c.state.Finished = time.Now()
+		return nil
+	}
+	if err != nil {
+		logrus.Warnf("failed to find process %d for container %q: %v", c.state.Pid, c.id, err)
+	} else {
+		err = process.Release()
+		if err != nil {
+			logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
+		}
+	}
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	if timeout > 0 {
+		if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.id, c.GetStopSignal()); err != nil {
+			if err := checkProcessGone(c); err != nil {
+				return fmt.Errorf("failed to stop container %q: %v", c.id, err)
+			}
+		}
+		err = waitContainerStop(ctx, c, time.Duration(timeout)*time.Second, true)
+		if err == nil {
+			return nil
+		}
+		logrus.Warnf("Stop container %q timed out: %v", c.id, err)
+	}
+
+	if err := utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.id, "KILL"); err != nil {
+		if err := checkProcessGone(c); err != nil {
+			return fmt.Errorf("failed to stop container %q: %v", c.id, err)
+		}
+	}
+
+	return waitContainerStop(ctx, c, killContainerTimeout, false)
+}
+
+func checkProcessGone(c *Container) error {
+	process, perr := findprocess.FindProcess(c.state.Pid)
+	if perr == findprocess.ErrNotFound {
+		c.state.Finished = time.Now()
+		return nil
+	}
+	if perr == nil {
+		err := process.Release()
+		if err != nil {
+			logrus.Warnf("failed to release process %d for container %q: %v", c.state.Pid, c.id, err)
+		}
+	}
+	return fmt.Errorf("failed to find process: %v", perr)
+}
+
+// DeleteContainer deletes a container.
+func (r *RuntimeV1) DeleteContainer(c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	_, err = utils.ExecCmd(rPath, "delete", "--force", c.id)
+	return err
+}
+
+// UpdateStatus refreshes the status of the container.
+func (r *RuntimeV1) UpdateStatus(c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	out, err := exec.Command(rPath, "state", c.id).Output()
+	if err != nil {
+		// there are many code paths that could lead to have a bad state in the
+		// underlying runtime.
+		// On any error like a container went away or we rebooted and containers
+		// went away we do not error out stopping kubernetes to recover.
+		// We always populate the fields below so kube can restart/reschedule
+		// containers failing.
+		c.state.Status = ContainerStateStopped
+		c.state.Finished = time.Now()
+		c.state.ExitCode = 255
+		return nil
+	}
+	if err := json.NewDecoder(bytes.NewBuffer(out)).Decode(&c.state); err != nil {
+		return fmt.Errorf("failed to decode container status for %s: %s", c.id, err)
+	}
+
+	if c.state.Status == ContainerStateStopped {
+		exitFilePath := filepath.Join(r.containerExitsDir, c.id)
+		var fi os.FileInfo
+		err = kwait.ExponentialBackoff(
+			kwait.Backoff{
+				Duration: 500 * time.Millisecond,
+				Factor:   1.2,
+				Steps:    6,
+			},
+			func() (bool, error) {
+				var err error
+				fi, err = os.Stat(exitFilePath)
+				if err != nil {
+					// wait longer
+					return false, nil
+				}
+				return true, nil
+			})
+		if err != nil {
+			logrus.Warnf("failed to find container exit file for %v: %v", c.id, err)
+			c.state.ExitCode = -1
+		} else {
+			c.state.Finished = getFinishedTime(fi)
+			statusCodeStr, err := ioutil.ReadFile(exitFilePath)
+			if err != nil {
+				return fmt.Errorf("failed to read exit file: %v", err)
+			}
+			statusCode, err := strconv.Atoi(string(statusCodeStr))
+			if err != nil {
+				return fmt.Errorf("status code conversion failed: %v", err)
+			}
+			c.state.ExitCode = int32(statusCode)
+		}
+
+		oomFilePath := filepath.Join(c.bundlePath, "oom")
+		if _, err = os.Stat(oomFilePath); err == nil {
+			c.state.OOMKilled = true
+		}
+	}
+
+	return nil
+}
+
+// PauseContainer pauses a container.
+func (r *RuntimeV1) PauseContainer(c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	_, err = utils.ExecCmd(rPath, "pause", c.id)
+	return err
+}
+
+// UnpauseContainer unpauses a container.
+func (r *RuntimeV1) UnpauseContainer(c *Container) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	_, err = utils.ExecCmd(rPath, "resume", c.id)
+	return err
+}
+
+// ContainerStats provides statistics of a container.
+func (r *RuntimeV1) ContainerStats(c *Container) (*ContainerStats, error) {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	return containerStats(c)
+}
+
+// SignalContainer sends a signal to a container process.
+func (r *RuntimeV1) SignalContainer(c *Container, sig syscall.Signal) error {
+	c.opLock.Lock()
+	defer c.opLock.Unlock()
+
+	signalString, err := findStringInSignalMap(sig)
+	if err != nil {
+		return err
+	}
+
+	rPath, err := r.path(c)
+	if err != nil {
+		return err
+	}
+
+	return utils.ExecCmdWithStdStreams(os.Stdin, os.Stdout, os.Stderr, rPath, "kill", c.ID(), signalString)
+}
+
+// AttachContainer attaches IO to a running container.
+func (r *RuntimeV1) AttachContainer(c *Container, inputStream io.Reader, outputStream, errorStream io.Writer, tty bool, resize <-chan remotecommand.TerminalSize) error {
+	controlPath := filepath.Join(c.BundlePath(), "ctl")
+	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open container ctl file: %v", err)
+	}
+	defer controlFile.Close()
+
+	kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
+		logrus.Debugf("Got a resize event: %+v", size)
+		_, err := fmt.Fprintf(controlFile, "%d %d %d\n", 1, size.Height, size.Width)
+		if err != nil {
+			logrus.Debugf("Failed to write to control file to resize terminal: %v", err)
+		}
+	})
+
+	attachSocketPath := filepath.Join(r.containerAttachSocketDir, c.ID(), "attach")
+	conn, err := net.DialUnix("unixpacket", nil, &net.UnixAddr{Name: attachSocketPath, Net: "unixpacket"})
+	if err != nil {
+		return fmt.Errorf("failed to connect to container %s attach socket: %v", c.ID(), err)
+	}
+	defer conn.Close()
+
+	receiveStdout := make(chan error)
+	if outputStream != nil || errorStream != nil {
+		go func() {
+			receiveStdout <- redirectResponseToOutputStreams(outputStream, errorStream, conn)
+		}()
+	}
+
+	stdinDone := make(chan error)
+	go func() {
+		var err error
+		if inputStream != nil {
+			_, err = utils.CopyDetachable(conn, inputStream, nil)
+			conn.CloseWrite()
+		}
+		stdinDone <- err
+	}()
+
+	select {
+	case err := <-receiveStdout:
+		return err
+	case err := <-stdinDone:
+		if _, ok := err.(utils.DetachError); ok {
+			return nil
+		}
+		if outputStream != nil || errorStream != nil {
+			return <-receiveStdout
+		}
+	}
+
+	return nil
+}
+
+// PortForwardContainer forwards the specified port provides statistics of a container.
+func (r *RuntimeV1) PortForwardContainer(c *Container, port int32, stream io.ReadWriter) error {
+	containerPid := c.State().Pid
+	socatPath, lookupErr := exec.LookPath("socat")
+	if lookupErr != nil {
+		return fmt.Errorf("unable to do port forwarding: socat not found")
+	}
+
+	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
+
+	nsenterPath, lookupErr := exec.LookPath("nsenter")
+	if lookupErr != nil {
+		return fmt.Errorf("unable to do port forwarding: nsenter not found")
+	}
+
+	commandString := fmt.Sprintf("%s %s", nsenterPath, strings.Join(args, " "))
+	logrus.Debugf("executing port forwarding command: %s", commandString)
+
+	command := exec.Command(nsenterPath, args...)
+	command.Stdout = stream
+
+	stderr := new(bytes.Buffer)
+	command.Stderr = stderr
+
+	// If we use Stdin, command.Run() won't return until the goroutine that's copying
+	// from stream finishes. Unfortunately, if you have a client like telnet connected
+	// via port forwarding, as long as the user's telnet client is connected to the user's
+	// local listener that port forwarding sets up, the telnet session never exits. This
+	// means that even if socat has finished running, command.Run() won't ever return
+	// (because the client still has the connection and stream open).
+	//
+	// The work around is to use StdinPipe(), as Wait() (called by Run()) closes the pipe
+	// when the command (socat) exits.
+	inPipe, err := command.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("unable to do port forwarding: error creating stdin pipe: %v", err)
+	}
+	go func() {
+		pools.Copy(inPipe, stream)
+		inPipe.Close()
+	}()
+
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("%v: %s", err, stderr.String())
+	}
+
+	return nil
+}
+
+// ReopenContainerLog reopens the log file of a container.
+func (r *RuntimeV1) ReopenContainerLog(c *Container) error {
+	controlPath := filepath.Join(c.BundlePath(), "ctl")
+	controlFile, err := os.OpenFile(controlPath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open container ctl file: %v", err)
+	}
+	defer controlFile.Close()
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("Failed to create new watch: %v", err)
+	}
+	defer watcher.Close()
+
+	done := make(chan struct{})
+	errorCh := make(chan error)
+	go func() {
+		for {
+			select {
+			case event := <-watcher.Events:
+				logrus.Debugf("event: %v", event)
+				if event.Op&fsnotify.Create == fsnotify.Create || event.Op&fsnotify.Write == fsnotify.Write {
+					logrus.Debugf("file created %s", event.Name)
+					if event.Name == c.LogPath() {
+						logrus.Debugf("expected log file created")
+						close(done)
+						return
+					}
+				}
+			case err := <-watcher.Errors:
+				errorCh <- fmt.Errorf("watch error for container log reopen %v: %v", c.ID(), err)
+				return
+			}
+		}
+	}()
+	cLogDir := filepath.Dir(c.LogPath())
+	if err := watcher.Add(cLogDir); err != nil {
+		logrus.Errorf("watcher.Add(%q) failed: %s", cLogDir, err)
+		close(done)
+	}
+
+	if _, err = fmt.Fprintf(controlFile, "%d %d %d\n", 2, 0, 0); err != nil {
+		logrus.Debugf("Failed to write to control file to reopen log file: %v", err)
+	}
+
+	select {
+	case err := <-errorCh:
+		return err
+	case <-done:
+		break
+	}
+
+	return nil
+}
+
+// prepareProcessExec returns the path of the process.json used in runc exec -p
+// caller is responsible to close the returned *os.File if needed.
+func prepareProcessExec(c *Container, cmd []string, tty bool) (*os.File, error) {
+	f, err := ioutil.TempFile("", "exec-process-")
+	if err != nil {
+		return nil, err
+	}
+
+	pspec := c.Spec().Process
+	pspec.Args = cmd
+	// We need to default this to false else it will inherit terminal as true
+	// from the container.
+	pspec.Terminal = false
+	if tty {
+		pspec.Terminal = true
+	}
+	processJSON, err := json.Marshal(pspec)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ioutil.WriteFile(f.Name(), processJSON, 0644); err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -36,7 +36,7 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 		return fmt.Errorf("could not find container %q: %v", containerID, err)
 	}
 
-	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
 		return err
 	}
 

--- a/server/container_attach.go
+++ b/server/container_attach.go
@@ -40,7 +40,7 @@ func (ss streamService) Attach(containerID string, inputStream io.Reader, output
 		return err
 	}
 
-	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
+	cState := c.State()
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -566,7 +566,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		}
 	}
 	// Join the namespace paths for the pod sandbox container.
-	podInfraState := s.Runtime().ContainerStatus(sb.InfraContainer())
+	podInfraState := sb.InfraContainer().State()
 
 	logrus.Debugf("pod container state %+v", podInfraState)
 

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -37,7 +37,7 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 		return fmt.Errorf("could not find container %q: %v", containerID, err)
 	}
 
-	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
 		return err
 	}
 
@@ -46,5 +46,5 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 		return fmt.Errorf("container is not created or running")
 	}
 
-	return ss.runtimeServer.Runtime().Exec(c, cmd, stdin, stdout, stderr, tty, resize)
+	return ss.runtimeServer.Runtime().ExecContainer(c, cmd, stdin, stdout, stderr, tty, resize)
 }

--- a/server/container_exec.go
+++ b/server/container_exec.go
@@ -41,7 +41,7 @@ func (ss streamService) Exec(containerID string, cmd []string, stdin io.Reader, 
 		return err
 	}
 
-	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
+	cState := c.State()
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -27,7 +27,7 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		return nil, err
 	}
 
-	cState := s.Runtime().ContainerStatus(c)
+	cState := c.State()
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return nil, fmt.Errorf("container is not created or running")
 	}

--- a/server/container_execsync.go
+++ b/server/container_execsync.go
@@ -23,7 +23,7 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		return nil, err
 	}
 
-	if err = s.Runtime().UpdateStatus(c); err != nil {
+	if err = s.Runtime().UpdateContainerStatus(c); err != nil {
 		return nil, err
 	}
 
@@ -37,7 +37,7 @@ func (s *Server) ExecSync(ctx context.Context, req *pb.ExecSyncRequest) (resp *p
 		return nil, fmt.Errorf("exec command cannot be empty")
 	}
 
-	execResp, err := s.Runtime().ExecSync(c, cmd, req.Timeout)
+	execResp, err := s.Runtime().ExecSyncContainer(c, cmd, req.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -90,7 +90,7 @@ func (s *Server) ListContainers(ctx context.Context, req *pb.ListContainersReque
 			continue
 		}
 		podSandboxID := ctr.Sandbox()
-		cState := s.Runtime().CurrentContainerStatus(ctr)
+		cState := ctr.StateNoLock()
 		created := ctr.CreatedAt().UnixNano()
 		rState := pb.ContainerState_CONTAINER_UNKNOWN
 		cID := ctr.ID()

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -43,7 +43,7 @@ func (ss streamService) PortForward(podSandboxID string, port int32, stream io.R
 		return err
 	}
 
-	cState := ss.runtimeServer.Runtime().ContainerStatus(c)
+	cState := c.State()
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return fmt.Errorf("container is not created or running")
 	}

--- a/server/container_portforward.go
+++ b/server/container_portforward.go
@@ -39,7 +39,7 @@ func (ss streamService) PortForward(podSandboxID string, port int32, stream io.R
 		return fmt.Errorf("could not find container for sandbox %q", podSandboxID)
 	}
 
-	if err := ss.runtimeServer.Runtime().UpdateStatus(c); err != nil {
+	if err := ss.runtimeServer.Runtime().UpdateContainerStatus(c); err != nil {
 		return err
 	}
 

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -30,7 +30,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 		return nil, err
 	}
 
-	cState := s.ContainerServer.Runtime().ContainerStatus(c)
+	cState := c.State()
 	if !(cState.Status == oci.ContainerStateRunning || cState.Status == oci.ContainerStateCreated) {
 		return nil, fmt.Errorf("container is not created or running")
 	}

--- a/server/container_reopen_log.go
+++ b/server/container_reopen_log.go
@@ -26,7 +26,7 @@ func (s *Server) ReopenContainerLog(ctx context.Context, req *pb.ReopenContainer
 		return nil, fmt.Errorf("could not find container %q", containerID)
 	}
 
-	if err := s.ContainerServer.Runtime().UpdateStatus(c); err != nil {
+	if err := s.ContainerServer.Runtime().UpdateContainerStatus(c); err != nil {
 		return nil, err
 	}
 

--- a/server/container_start.go
+++ b/server/container_start.go
@@ -22,7 +22,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 	if err != nil {
 		return nil, err
 	}
-	state := s.Runtime().ContainerStatus(c)
+	state := c.State()
 	if state.Status != oci.ContainerStateCreated {
 		return nil, fmt.Errorf("container %s is not in created state: %s", c.ID(), state.Status)
 	}
@@ -33,7 +33,7 @@ func (s *Server) StartContainer(ctx context.Context, req *pb.StartContainerReque
 		// adjust container started/finished time and set an error to be
 		// returned in the Reason field for container status call.
 		if err != nil {
-			s.Runtime().SetStartFailed(c, err)
+			c.SetStartFailed(err)
 		}
 		s.ContainerStateToDisk(c)
 	}()

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -55,7 +55,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	}
 	resp.Status.Mounts = mounts
 
-	cState := s.Runtime().ContainerStatus(c)
+	cState := c.State()
 	rStatus := pb.ContainerState_CONTAINER_UNKNOWN
 
 	// If we defaulted to exit code -1 earlier then we attempt to
@@ -65,7 +65,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 		if err != nil {
 			logrus.Warnf("Failed to UpdateStatus of container %s: %v", c.ID(), err)
 		}
-		cState = s.Runtime().ContainerStatus(c)
+		cState = c.State()
 	}
 
 	created := c.CreatedAt().UnixNano()

--- a/server/container_status.go
+++ b/server/container_status.go
@@ -61,7 +61,7 @@ func (s *Server) ContainerStatus(ctx context.Context, req *pb.ContainerStatusReq
 	// If we defaulted to exit code -1 earlier then we attempt to
 	// get the exit code from the exit file again.
 	if cState.ExitCode == -1 {
-		err := s.Runtime().UpdateStatus(c)
+		err := s.Runtime().UpdateContainerStatus(c)
 		if err != nil {
 			logrus.Warnf("Failed to UpdateStatus of container %s: %v", c.ID(), err)
 		}

--- a/server/container_update_resources.go
+++ b/server/container_update_resources.go
@@ -25,7 +25,7 @@ func (s *Server) UpdateContainerResources(ctx context.Context, req *pb.UpdateCon
 	if err != nil {
 		return nil, err
 	}
-	state := s.Runtime().ContainerStatus(c)
+	state := c.State()
 	if !(state.Status == oci.ContainerStateRunning || state.Status == oci.ContainerStateCreated) {
 		return nil, fmt.Errorf("container %s is not running or created state: %s", c.ID(), state.Status)
 	}

--- a/server/sandbox_list.go
+++ b/server/sandbox_list.go
@@ -74,7 +74,7 @@ func (s *Server) ListPodSandbox(ctx context.Context, req *pb.ListPodSandboxReque
 			// it's better not to panic
 			continue
 		}
-		cState := s.Runtime().CurrentContainerStatus(podInfraContainer)
+		cState := podInfraContainer.StateNoLock()
 		rStatus := pb.PodSandboxState_SANDBOX_NOTREADY
 		if cState.Status == oci.ContainerStateRunning {
 			rStatus = pb.PodSandboxState_SANDBOX_READY

--- a/server/sandbox_remove.go
+++ b/server/sandbox_remove.go
@@ -46,7 +46,7 @@ func (s *Server) RemovePodSandbox(ctx context.Context, req *pb.RemovePodSandboxR
 	// Delete all the containers in the sandbox
 	for _, c := range containers {
 		if !sb.Stopped() {
-			cState := s.Runtime().ContainerStatus(c)
+			cState := c.State()
 			if cState.Status == oci.ContainerStateCreated || cState.Status == oci.ContainerStateRunning {
 				timeout := int64(10)
 				if err := s.Runtime().StopContainer(ctx, c, timeout); err != nil {

--- a/server/sandbox_status.go
+++ b/server/sandbox_status.go
@@ -24,7 +24,7 @@ func (s *Server) PodSandboxStatus(ctx context.Context, req *pb.PodSandboxStatusR
 	}
 
 	podInfraContainer := sb.InfraContainer()
-	cState := s.Runtime().ContainerStatus(podInfraContainer)
+	cState := podInfraContainer.State()
 
 	rStatus := pb.PodSandboxState_SANDBOX_NOTREADY
 	if cState.Status == oci.ContainerStateRunning {

--- a/server/sandbox_stop_linux.go
+++ b/server/sandbox_stop_linux.go
@@ -70,7 +70,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 			max = len(containers)
 		}
 		for _, ctr := range containers[i:max] {
-			cStatus := s.Runtime().ContainerStatus(ctr)
+			cStatus := ctr.State()
 			if cStatus.Status != oci.ContainerStateStopped {
 				if ctr.ID() == podInfraContainer.ID() {
 					continue
@@ -98,7 +98,7 @@ func (s *Server) stopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		}
 	}
 
-	podInfraStatus := s.Runtime().ContainerStatus(podInfraContainer)
+	podInfraStatus := podInfraContainer.State()
 	if podInfraStatus.Status != oci.ContainerStateStopped {
 		timeout := int64(10)
 		if err := s.Runtime().StopContainer(ctx, podInfraContainer, timeout); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -492,7 +492,7 @@ func (s *Server) StartExitMonitor() {
 					c := s.GetContainer(containerID)
 					if c != nil {
 						logrus.Debugf("container exited and found: %v", containerID)
-						err := s.Runtime().UpdateStatus(c)
+						err := s.Runtime().UpdateContainerStatus(c)
 						if err != nil {
 							logrus.Warnf("Failed to update container status %s: %v", containerID, err)
 						} else {
@@ -503,7 +503,7 @@ func (s *Server) StartExitMonitor() {
 						if sb != nil {
 							c := sb.InfraContainer()
 							logrus.Debugf("sandbox exited and found: %v", containerID)
-							err := s.Runtime().UpdateStatus(c)
+							err := s.Runtime().UpdateContainerStatus(c)
 							if err != nil {
 								logrus.Warnf("Failed to update sandbox infra container status %s: %v", c.ID(), err)
 							} else {


### PR DESCRIPTION
oci: Abstract Runtime structure as a Go interface

This is the second step in making a clear separation between different
implementations of the runtime. This commit takes care of defining a
new Go interface RuntimeImpl that can be implemented depending on the
runtime version.

One technical detail is that we had to maintain Runtime as a Go
structure embedding this new Go interface, since there are a few
fields that are common to every implementations. Those common
fields are gathered beneath the new structure RuntimeBase.

Once the abstraction is clearly defined, this patch reuses the
former runtime implementation as the RuntimeV1 implementation.

Fixes #1989

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>