### PR TITLE
Remove unused variable in Makefile that was used to exclude vendor packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ BASHINSTALLDIR=${PREFIX}/share/bash-completion/completions
 OCIUMOUNTINSTALLDIR=$(PREFIX)/share/oci-umount/oci-umount.d
 
 SELINUXOPT ?= $(shell selinuxenabled 2>/dev/null && echo -Z)
-PACKAGES ?= $(shell go list -tags "${BUILDTAGS}" ./... | grep -v github.com/kubernetes-sigs/cri-o/vendor)
 
 BUILD_INFO := $(shell date +%s)
 


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>


**- What I did**
I was building and found a variable that I thought was going to help me to conditionally exclude packages from tests, it turned out the variable is not used so I removed it.

**- How I did it**
dd

**- How to verify it**


**- Description for the changelog**

