### PR TITLE
oci: read conmon process status

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -313,6 +313,7 @@ func (r *Runtime) CreateContainer(c *Container, cgroupParent string) (err error)
 	someData := []byte{0}
 	_, err = parentStartPipe.Write(someData)
 	if err != nil {
+		cmd.Wait()
 		return err
 	}
 


### PR DESCRIPTION
be sure we don't leave the conmon process around if we fail to write
to the start pipe.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

