### PR TITLE
oci: Extend container stop timeout

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -55,7 +55,7 @@ const (
 	// minCtrStopTimeout is the minimal amout of time in seconds to wait
 	// before issuing a timeout regarding the proper termination of the
 	// container.
-	minCtrStopTimeout = 10
+	minCtrStopTimeout = 30
 
 	// UntrustedRuntime is the implicit runtime handler name used to
 	// fallback to the untrusted runtime.


### PR DESCRIPTION
With the recent introduction of the parallelization of multiple
containers stop, it might take more than 10 seconds to stop a
container running with Kata Containers, given the fact that the
CI runs in a nested environment.

This patch extends the minimum timeout to a larger value of 30
seconds to ensure the CI will not run into this issue anymore.

Fixes #2012

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>