### PR TITLE
Add oci unit tests

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -333,7 +333,9 @@ func (c *Container) SetStartFailed(err error) {
 	defer c.opLock.Unlock()
 	// adjust finished and started times
 	c.state.Finished, c.state.Started = c.state.Created, c.state.Created
-	c.state.Error = err.Error()
+	if err != nil {
+		c.state.Error = err.Error()
+	}
 }
 
 // Description returns a description for the container

--- a/oci/container_test.go
+++ b/oci/container_test.go
@@ -1,0 +1,254 @@
+package oci_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/kubernetes-sigs/cri-o/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+// The actual test suite
+var _ = t.Describe("Container", func() {
+	// The system under test
+	var sut *oci.Container
+
+	// Setup the test
+	BeforeEach(func() {
+		sut = getTestContainer()
+	})
+
+	It("should succeed to get the container fields", func() {
+		// Given
+		// When
+		// Then
+		Expect(sut.ID()).To(Equal("id"))
+		Expect(sut.Name()).To(Equal("name"))
+		Expect(sut.BundlePath()).To(Equal("bundlePath"))
+		Expect(sut.LogPath()).To(Equal("logPath"))
+		Expect(len(sut.Labels())).To(BeEquivalentTo(1))
+		Expect(len(sut.Annotations())).To(BeEquivalentTo(1))
+		Expect(len(sut.CrioAnnotations())).To(BeEquivalentTo(1))
+		Expect(sut.Image()).To(Equal("image"))
+		Expect(sut.ImageName()).To(Equal("imageName"))
+		Expect(sut.ImageRef()).To(Equal("imageRef"))
+		Expect(sut.Sandbox()).To(Equal("sandbox"))
+		Expect(sut.Dir()).To(Equal("dir"))
+		Expect(sut.NetNsPath()).To(Equal("netns"))
+		Expect(sut.StatePath()).To(Equal("dir/state.json"))
+		Expect(sut.Metadata()).To(Equal(&pb.ContainerMetadata{}))
+		Expect(sut.StateNoLock().Version).To(BeEmpty())
+		Expect(sut.GetStopSignal()).To(Equal("TERM"))
+		Expect(sut.CreatedAt().UnixNano()).
+			To(BeNumerically("<", time.Now().UnixNano()))
+	})
+
+	It("should succeed to set the spec", func() {
+		// Given
+		newSpec := specs.Spec{Version: "version"}
+
+		// When
+		sut.SetSpec(&newSpec)
+
+		// Then
+		Expect(sut.Spec()).To(Equal(newSpec))
+	})
+
+	It("should succeed to set created", func() {
+		// Given
+		Expect(sut.Created()).To(BeFalse())
+
+		// When
+		sut.SetCreated()
+
+		// Then
+		Expect(sut.Created()).To(BeTrue())
+	})
+
+	It("should succeed to set ID mappings", func() {
+		// Given
+		mappings := &idtools.IDMappings{}
+
+		// When
+		sut.SetIDMappings(mappings)
+
+		// Then
+		Expect(sut.IDMappings()).To(Equal(mappings))
+	})
+
+	It("should succeed to add a volume", func() {
+		// Given
+		volume := oci.ContainerVolume{ContainerPath: "/"}
+
+		// When
+		sut.AddVolume(volume)
+
+		// Then
+		Expect(len(sut.Volumes())).To(BeEquivalentTo(1))
+		Expect(sut.Volumes()[0]).To(Equal(volume))
+	})
+
+	It("should succeed to set the seccomp profile path", func() {
+		// Given
+		path := "path"
+
+		// When
+		sut.SetSeccompProfilePath(path)
+
+		// Then
+		Expect(sut.SeccompProfilePath()).To(Equal(path))
+	})
+
+	It("should succeed to set the mount point", func() {
+		// Given
+		mp := "mountPoint"
+
+		// When
+		sut.SetMountPoint(mp)
+
+		// Then
+		Expect(sut.MountPoint()).To(Equal(mp))
+	})
+
+	It("should succeed to set the intermediate mount point", func() {
+		// Given
+		mp := "intermediateMountPoint"
+
+		// When
+		sut.SetIntermediateMountPoint(mp)
+
+		// Then
+		Expect(sut.IntermediateMountPoint()).To(Equal(mp))
+	})
+
+	It("should succeed to set start failed", func() {
+		// Given
+		err := fmt.Errorf("error")
+
+		// When
+		sut.SetStartFailed(err)
+
+		// Then
+		Expect(sut.State().Error).To(Equal(err.Error()))
+	})
+
+	It("should succeed to set start failed with nil error", func() {
+		// Given
+		// When
+		sut.SetStartFailed(nil)
+
+		// Then
+		Expect(sut.State().Error).To(BeEmpty())
+	})
+
+	It("should succeed get the default stop signal on invalid", func() {
+		// Given
+		container, err := oci.NewContainer("", "", "", "", "",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"", "", "", &pb.ContainerMetadata{}, "",
+			false, false, false, false, false, "", "", time.Now(), "SIGNO")
+		Expect(err).To(BeNil())
+		Expect(container).NotTo(BeNil())
+
+		// When
+		signal := container.GetStopSignal()
+
+		// Then
+		Expect(signal).To(Equal("TERM"))
+	})
+
+	It("should succeed get NetNsPath if not provided", func() {
+		// Given
+		container, err := oci.NewContainer("", "", "", "", "",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"", "", "", &pb.ContainerMetadata{}, "",
+			false, false, false, false, false, "", "", time.Now(), "")
+		Expect(err).To(BeNil())
+		Expect(container).NotTo(BeNil())
+
+		// When
+		path, err := container.NetNsPath()
+
+		// Then
+		Expect(err).To(BeNil())
+		Expect(path).To(Equal("/proc/0/ns/net"))
+	})
+
+	It("should fail get NetNsPath if container state nil", func() {
+		// Given
+		container, err := oci.NewContainer("", "", "", "", "",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"", "", "", &pb.ContainerMetadata{}, "",
+			false, false, false, false, false, "", "", time.Now(), "")
+		Expect(err).To(BeNil())
+		Expect(container).NotTo(BeNil())
+		container.SetState(nil)
+
+		// When
+		path, err := container.NetNsPath()
+
+		// Then
+		Expect(err).NotTo(BeNil())
+		Expect(path).To(BeEmpty())
+	})
+
+	It("should succeed get the non default stop signal", func() {
+		// Given
+		container, err := oci.NewContainer("", "", "", "", "",
+			map[string]string{}, map[string]string{}, map[string]string{},
+			"", "", "", &pb.ContainerMetadata{}, "",
+			false, false, false, false, false, "", "", time.Now(), "SIGTRAP")
+		Expect(err).To(BeNil())
+		Expect(container).NotTo(BeNil())
+
+		// When
+		signal := container.GetStopSignal()
+
+		// Then
+		Expect(signal).To(Equal("TRAP"))
+	})
+
+	It("should succeed to get the state from disk", func() {
+		// Given
+		Expect(os.MkdirAll(sut.Dir(), 0755)).To(BeNil())
+		Expect(ioutil.WriteFile(path.Join(sut.Dir(), "state.json"),
+			[]byte("{}"), 0644)).To(BeNil())
+		defer os.RemoveAll(sut.Dir())
+
+		// When
+		err := sut.FromDisk()
+
+		// Then
+		Expect(err).To(BeNil())
+	})
+
+	It("should fail to get the state from disk if invalid json", func() {
+		// Given
+		Expect(os.MkdirAll(sut.Dir(), 0755)).To(BeNil())
+		Expect(ioutil.WriteFile(path.Join(sut.Dir(), "state.json"),
+			[]byte("invalid"), 0644)).To(BeNil())
+		defer os.RemoveAll(sut.Dir())
+
+		// When
+		err := sut.FromDisk()
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+
+	It("should fail to get the state from disk if not existing", func() {
+		// Given
+		// When
+		err := sut.FromDisk()
+
+		// Then
+		Expect(err).NotTo(BeNil())
+	})
+})

--- a/oci/history_test.go
+++ b/oci/history_test.go
@@ -1,0 +1,47 @@
+package oci_test
+
+import (
+	"github.com/kubernetes-sigs/cri-o/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("History", func() {
+	// The system under test
+	var sut oci.History
+
+	// Setup the test
+	BeforeEach(func() {
+		testContainer1 := getTestContainer()
+		testContainer2 := getTestContainer()
+		sut = oci.History([]*oci.Container{testContainer1, testContainer2})
+	})
+
+	It("should succeed to get the history len", func() {
+		// Given
+		// When
+		// Then
+		Expect(sut.Len()).To(BeEquivalentTo(2))
+	})
+
+	It("should succeed compare the creation time", func() {
+		// Given
+		// When
+		res := sut.Less(1, 0)
+
+		// Then
+		Expect(res).To(BeTrue())
+	})
+
+	It("should succeed to swap items", func() {
+		// Given
+		sut.Swap(0, 1)
+
+		// When
+		res := sut.Less(1, 0)
+
+		// Then
+		Expect(res).To(BeFalse())
+	})
+})

--- a/oci/memory_store.go
+++ b/oci/memory_store.go
@@ -57,7 +57,7 @@ func (c *memoryStore) Size() int {
 // First returns the first container found in the store by a given filter.
 func (c *memoryStore) First(filter StoreFilter) *Container {
 	for _, cont := range c.all() {
-		if filter(cont) {
+		if filter == nil || filter(cont) {
 			return cont
 		}
 	}
@@ -68,6 +68,9 @@ func (c *memoryStore) First(filter StoreFilter) *Container {
 // This operation is asynchronous in the memory store.
 // NOTE: Modifications to the store MUST NOT be done by the StoreReducer.
 func (c *memoryStore) ApplyAll(apply StoreReducer) {
+	if apply == nil {
+		return
+	}
 	wg := new(sync.WaitGroup)
 	for _, cont := range c.all() {
 		wg.Add(1)

--- a/oci/memory_store_test.go
+++ b/oci/memory_store_test.go
@@ -1,0 +1,167 @@
+package oci_test
+
+import (
+	"github.com/kubernetes-sigs/cri-o/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("MemoryStore", func() {
+	t.Describe("NewMemoryStore", func() {
+		It("should succeed to create a new memory store", func() {
+			// Given
+			// When
+			store := oci.NewMemoryStore()
+
+			// Then
+			Expect(store).NotTo(BeNil())
+		})
+	})
+
+	t.Describe("MemoryStore", func() {
+		var (
+			sut           oci.ContainerStorer
+			testContainer *oci.Container
+		)
+
+		const containerID = "id"
+
+		// Setup the test
+		BeforeEach(func() {
+			testContainer = getTestContainer()
+			sut = oci.NewMemoryStore()
+			Expect(sut).NotTo(BeNil())
+		})
+
+		It("should succeed to add a new container", func() {
+			// Given
+			// When
+			sut.Add(containerID, testContainer)
+
+			// Then
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+			Expect(sut.Size()).To(BeEquivalentTo(1))
+		})
+
+		It("should succeed to delete a container", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			sut.Delete(containerID)
+
+			// Then
+			Expect(sut.Get(containerID)).To(BeNil())
+			Expect(sut.Size()).To(BeZero())
+		})
+
+		It("should succeed to delete a non existing container", func() {
+			// Given
+			// When
+			sut.Delete(containerID)
+
+			// Then
+			Expect(sut.Get(containerID)).To(BeNil())
+			Expect(sut.Size()).To(BeZero())
+		})
+
+		It("should fail to get a non existing container", func() {
+			// Given
+			// When
+			// Then
+			Expect(sut.Get(containerID)).To(BeNil())
+			Expect(sut.Size()).To(BeZero())
+		})
+
+		It("should succeed to list containers", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			containers := sut.List()
+
+			// Then
+			Expect(containers).NotTo(BeNil())
+			Expect(len(containers)).To(BeEquivalentTo(1))
+			Expect(containers[0]).To(Equal(testContainer))
+		})
+
+		It("should succeed to list containers in an empty store", func() {
+			// Given
+			// When
+			containers := sut.List()
+
+			// Then
+			Expect(containers).NotTo(BeNil())
+			Expect(len(containers)).To(BeZero())
+		})
+
+		It("should succeed to get the first container with filter", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			container := sut.First(func(*oci.Container) bool { return true })
+
+			// Then
+			Expect(container).NotTo(BeNil())
+			Expect(container).To(Equal(testContainer))
+		})
+
+		It("should succeed to get the first container without filter", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			container := sut.First(nil)
+
+			// Then
+			Expect(container).NotTo(BeNil())
+			Expect(container).To(Equal(testContainer))
+		})
+
+		It("should fail to the first container with false filter", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			container := sut.First(func(*oci.Container) bool { return false })
+
+			// Then
+			Expect(container).To(BeNil())
+		})
+
+		It("should succeed apply", func() {
+			// Given
+			newContainerState := &oci.ContainerState{ExitCode: -1}
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			sut.ApplyAll(func(container *oci.Container) {
+				container.SetState(newContainerState)
+			})
+
+			// Then
+			Expect(sut.Get(containerID).State()).To(Equal(newContainerState))
+		})
+
+		It("should succeed apply without valid function", func() {
+			// Given
+			sut.Add(containerID, testContainer)
+			Expect(sut.Get(containerID)).NotTo(BeNil())
+
+			// When
+			sut.ApplyAll(nil)
+
+			// Then
+			Expect(sut.Get(containerID)).To(Equal(testContainer))
+		})
+	})
+})

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -1,0 +1,148 @@
+package oci_test
+
+import (
+	"github.com/kubernetes-sigs/cri-o/oci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// The actual test suite
+var _ = t.Describe("Oci", func() {
+	t.Describe("New", func() {
+		It("should succeed with default runtime", func() {
+			// Given
+			// When
+			runtime, err := oci.New("", "", "", "runc",
+				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", ""}},
+				"", []string{}, "", "", "", 0, false, 0, "")
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(runtime).NotTo(BeNil())
+		})
+
+		It("should fail if no runtime configured for default runtime", func() {
+			// Given
+			// When
+			runtime, err := oci.New("", "", "", "",
+				map[string]oci.RuntimeHandler{}, "", []string{},
+				"", "", "", 0, false, 0, "")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(runtime).To(BeNil())
+		})
+	})
+
+	t.Describe("Oci", func() {
+		// The system under test
+		var sut *oci.Runtime
+
+		// Test constants
+		const (
+			invalidRuntime     = "invalid"
+			defaultRuntime     = "runc"
+			runtimeTrustedPath = "runtimeTrustedPath"
+		)
+		runtimes := map[string]oci.RuntimeHandler{
+			defaultRuntime: {"/bin/sh", ""}, invalidRuntime: {},
+		}
+
+		BeforeEach(func() {
+			var err error
+			sut, err = oci.New(runtimeTrustedPath, "", "", defaultRuntime,
+				runtimes,
+				"", []string{}, "", "", "", 0, false, 0, "")
+
+			Expect(err).To(BeNil())
+			Expect(sut).NotTo(BeNil())
+		})
+
+		It("should succeed to retrieve the runtime base name", func() {
+			// Given
+			// When
+			result := sut.Name()
+
+			// Then
+			Expect(result).To(Equal(runtimeTrustedPath))
+		})
+
+		It("should succeed to retrieve the runtimes", func() {
+			// Given
+			// When
+			result := sut.Runtimes()
+
+			// Then
+			Expect(result).To(Equal(runtimes))
+		})
+
+		It("should succeed to validate a runtime handler", func() {
+			// Given
+			// When
+			handler, err := sut.ValidateRuntimeHandler(defaultRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(handler).To(Equal(runtimes[defaultRuntime]))
+		})
+
+		It("should succeed to validate the untrusted runtime", func() {
+			// Given
+			const untrustedPath = "untrustedPath"
+			sut, err := oci.New("", untrustedPath, "", defaultRuntime,
+				runtimes, "", []string{}, "", "", "", 0, false, 0, "")
+			Expect(err).To(BeNil())
+			Expect(sut).NotTo(BeNil())
+
+			// When
+			handler, err := sut.ValidateRuntimeHandler(oci.UntrustedRuntime)
+
+			// Then
+			Expect(err).To(BeNil())
+			Expect(handler.RuntimePath).To(Equal(untrustedPath))
+		})
+
+		It("should fail to validate an inexisting runtime handler", func() {
+			// Given
+			// When
+			handler, err := sut.ValidateRuntimeHandler("not_existing")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(handler).To(Equal(oci.RuntimeHandler{}))
+		})
+
+		It("should fail to validate an invalid runtime path", func() {
+			// Given
+			// When
+			handler, err := sut.ValidateRuntimeHandler(invalidRuntime)
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(handler).To(Equal(oci.RuntimeHandler{}))
+		})
+
+		It("should fail to validate an empty runtime handler", func() {
+			// Given
+			// When
+			handler, err := sut.ValidateRuntimeHandler("")
+
+			// Then
+			Expect(err).NotTo(BeNil())
+			Expect(handler).To(Equal(oci.RuntimeHandler{}))
+		})
+	})
+
+	t.Describe("ExecSyncError", func() {
+		It("should succeed to get the exec sync error", func() {
+			// Given
+			sut := oci.ExecSyncError{}
+
+			// When
+			result := sut.Error()
+
+			// Then
+			Expect(result).To(ContainSubstring("error"))
+		})
+	})
+})

--- a/oci/suite_test.go
+++ b/oci/suite_test.go
@@ -1,0 +1,53 @@
+package oci_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/kubernetes-sigs/cri-o/oci"
+	. "github.com/kubernetes-sigs/cri-o/test/framework"
+	"github.com/kubernetes-sigs/cri-o/test/mocks/containerstorage"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+// TestOci runs the created specs
+func TestOci(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Oci")
+}
+
+// nolint: gochecknoglobals
+var (
+	t         *TestFramework
+	mockCtrl  *gomock.Controller
+	storeMock *containerstoragemock.MockStore
+)
+
+var _ = BeforeSuite(func() {
+	t = NewTestFramework(NilFunc, NilFunc)
+	t.Setup()
+
+	// Setup the mocks
+	mockCtrl = gomock.NewController(GinkgoT())
+	storeMock = containerstoragemock.NewMockStore(mockCtrl)
+})
+
+func getTestContainer() *oci.Container {
+	container, err := oci.NewContainer("id", "name", "bundlePath", "logPath",
+		"netns", map[string]string{"key": "label"},
+		map[string]string{"key": "crioAnnotation"},
+		map[string]string{"key": "annotation"},
+		"image", "imageName", "imageRef", &pb.ContainerMetadata{}, "sandbox",
+		false, false, false, false, false, "", "dir", time.Now(), "")
+	Expect(err).To(BeNil())
+	Expect(container).NotTo(BeNil())
+	return container
+}
+
+var _ = AfterSuite(func() {
+	t.Teardown()
+	mockCtrl.Finish()
+})


### PR DESCRIPTION
This PR contains the unit tests of the `oci` package. The coverage is pretty low for now, because there is no lower level abstraction (like for system calls). 