### PR TITLE
Containers run as a USER should have UID in /etc/passwd

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -312,6 +312,7 @@ func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunD
 	}
 
 	specgen.SetProcessUID(uid)
+	specgen.SetProcessGID(gid)
 	if sc.GetRunAsGroup() != nil {
 		specgen.SetProcessGID(uint32(sc.GetRunAsGroup().GetValue()))
 	}

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,8 +16,8 @@ import (
 	"github.com/kubernetes-sigs/cri-o/lib/sandbox"
 	"github.com/kubernetes-sigs/cri-o/pkg/seccomp"
 	"github.com/kubernetes-sigs/cri-o/pkg/storage"
+	"github.com/kubernetes-sigs/cri-o/utils"
 	"github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/opencontainers/runc/libcontainer/user"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/sirupsen/logrus"
@@ -266,7 +265,7 @@ func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig
 }
 
 // setupContainerUser sets the UID, GID and supplemental groups in OCI runtime config
-func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.LinuxContainerSecurityContext, imageConfig *v1.Image) error {
+func setupContainerUser(specgen *generate.Generator, rootfs, mountLabel, ctrRunDir string, sc *pb.LinuxContainerSecurityContext, imageConfig *v1.Image) error {
 	if sc == nil {
 		return nil
 	}
@@ -285,13 +284,31 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 	if err != nil {
 		return err
 	}
-
 	logrus.Debugf("CONTAINER USER: %+v", containerUser)
 
 	// Add uid, gid and groups from user
-	uid, _, addGroups, err := getUserInfo(rootfs, containerUser)
+	uid, gid, addGroups, err := utils.GetUserInfo(rootfs, containerUser)
 	if err != nil {
 		return err
+	}
+
+	// verify uid exists in containers /etc/passwd, else generate a passwd with the user entry
+	passwdPath, err := utils.GeneratePasswd(uid, gid, rootfs, ctrRunDir)
+	if err != nil {
+		return err
+	}
+	if passwdPath != "" {
+		if err := securityLabel(passwdPath, mountLabel, false); err != nil {
+			return err
+		}
+
+		mnt := rspec.Mount{
+			Type:        "bind",
+			Source:      passwdPath,
+			Destination: "/etc/passwd",
+			Options:     []string{"ro", "bind", "nodev", "nosuid", "noexec"},
+		}
+		specgen.AddMount(mnt)
 	}
 
 	specgen.SetProcessUID(uid)
@@ -633,47 +650,4 @@ func (s *Server) getAppArmorProfileName(profile string) string {
 	}
 
 	return strings.TrimPrefix(profile, apparmorLocalHostPrefix)
-}
-
-// openContainerFile opens a file inside a container rootfs safely
-func openContainerFile(rootfs string, path string) (io.ReadCloser, error) {
-	fp, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, path), rootfs)
-	if err != nil {
-		return nil, err
-	}
-	return os.Open(fp)
-}
-
-// getUserInfo returns UID, GID and additional groups for specified user
-// by looking them up in /etc/passwd and /etc/group
-func getUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, error) {
-	// We don't care if we can't open the file because
-	// not all images will have these files
-	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")
-	if err != nil {
-		logrus.Warnf("Failed to open /etc/passwd: %v", err)
-	} else {
-		defer passwdFile.Close()
-	}
-
-	groupFile, err := openContainerFile(rootfs, "/etc/group")
-	if err != nil {
-		logrus.Warnf("Failed to open /etc/group: %v", err)
-	} else {
-		defer groupFile.Close()
-	}
-
-	execUser, err := user.GetExecUser(userName, nil, passwdFile, groupFile)
-	if err != nil {
-		return 0, 0, nil, err
-	}
-
-	uid := uint32(execUser.Uid)
-	gid := uint32(execUser.Gid)
-	var additionalGids []uint32
-	for _, g := range execUser.Sgids {
-		additionalGids = append(additionalGids, uint32(g))
-	}
-
-	return uid, gid, additionalGids, nil
 }

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -887,7 +887,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	// Setup user and groups
 	if linux != nil {
-		if err = setupContainerUser(&specgen, mountPoint, linux.GetSecurityContext(), containerImageConfig); err != nil {
+		if err = setupContainerUser(&specgen, mountPoint, mountLabel, containerInfo.RunDir, linux.GetSecurityContext(), containerImageConfig); err != nil {
 			return nil, err
 		}
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -5,11 +5,20 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+
+	"github.com/containers/libpod/pkg/lookup"
+	"github.com/docker/docker/pkg/symlink"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	systemdDbus "github.com/coreos/go-systemd/dbus"
 	"github.com/godbus/dbus"
@@ -182,4 +191,76 @@ func GenerateID() string {
 	b := make([]byte, 32)
 	rand.Read(b)
 	return hex.EncodeToString(b)
+}
+
+// openContainerFile opens a file inside a container rootfs safely
+func openContainerFile(rootfs string, path string) (io.ReadCloser, error) {
+	fp, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, path), rootfs)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(fp)
+}
+
+// GetUserInfo returns UID, GID and additional groups for specified user
+// by looking them up in /etc/passwd and /etc/group
+func GetUserInfo(rootfs string, userName string) (uint32, uint32, []uint32, error) {
+	// We don't care if we can't open the file because
+	// not all images will have these files
+	passwdFile, err := openContainerFile(rootfs, "/etc/passwd")
+	if err != nil {
+		logrus.Warnf("Failed to open /etc/passwd: %v", err)
+	} else {
+		defer passwdFile.Close()
+	}
+
+	groupFile, err := openContainerFile(rootfs, "/etc/group")
+	if err != nil {
+		logrus.Warnf("Failed to open /etc/group: %v", err)
+	} else {
+		defer groupFile.Close()
+	}
+
+	execUser, err := user.GetExecUser(userName, nil, passwdFile, groupFile)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+
+	uid := uint32(execUser.Uid)
+	gid := uint32(execUser.Gid)
+	var additionalGids []uint32
+	for _, g := range execUser.Sgids {
+		additionalGids = append(additionalGids, uint32(g))
+	}
+
+	return uid, gid, additionalGids, nil
+}
+
+// GeneratePasswd generates a container specific passwd file,
+// iff uid is not defined in the containers /etc/passwd
+func GeneratePasswd(uid, gid uint32, rootfs, rundir string) (string, error) {
+	// if UID exists inside of container rootfs /etc/passwd then
+	// don't generate passwd
+	if _, err := lookup.GetUser(rootfs, strconv.Itoa(int(uid))); err == nil {
+		return "", nil
+	}
+	passwdFile := filepath.Join(rundir, "passwd")
+	originPasswdFile, err := symlink.FollowSymlinkInScope(filepath.Join(rootfs, "/etc/passwd"), rootfs)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to follow symlinks to passwd file")
+	}
+	orig, err := ioutil.ReadFile(originPasswdFile)
+	if err != nil {
+		// If no /etc/passwd in container ignore and return
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", errors.Wrapf(err, "unable to read passwd file %s", originPasswdFile)
+	}
+
+	pwd := fmt.Sprintf("%s%d:x:%d:%d:container user:%s:/bin/sh\n", orig, uid, uid, gid, "/")
+	if err := ioutil.WriteFile(passwdFile, []byte(pwd), 0644); err != nil {
+		return "", errors.Wrapf(err, "failed to create temporary passwd file")
+	}
+	return passwdFile, nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -2,7 +2,9 @@ package utils_test
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kubernetes-sigs/cri-o/utils"
@@ -248,4 +250,277 @@ var _ = t.Describe("Utils", func() {
 			Expect(err).NotTo(BeNil())
 		})
 	})
+
+	t.Describe("GetUserInfo and GeneratePasswd", func() {
+		It("should succeed with nothing set i.e user=root", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "root")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file isn't created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "root")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with existing username", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "daemon")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file isn't created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with existing uid", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "25")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file isn't created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "25")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with uid that doesn't exist in /etc/passwd", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "300")
+			Expect(err).To(BeNil())
+
+			// passwdFile should not be empty because an updated /etc/passwd file is created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(Not(BeEmpty()))
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should fail with username that desn't exist in /etc/passwd", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			_, _, _, err := utils.GetUserInfo(dir, "blah")
+			Expect(err).To(Not(BeNil()))
+		})
+
+		It("should succeed with existing user and group", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "daemon:mail")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file is not created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:mail")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with existing uid and gid", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "2:22")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file is not created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "2:22")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with existing user and non-existing numeric gid", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "daemon:250")
+			Expect(err).To(BeNil())
+
+			// passwdFile should be empty because an updated /etc/passwd file is not created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(BeEmpty())
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "daemon:250")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with non-existing uid and non-existing gid", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "300:250")
+			Expect(err).To(BeNil())
+
+			// passwdFile should not be empty because an updated /etc/passwd file is created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(Not(BeEmpty()))
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:250")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+
+		It("should succeed with non-existing uid and existing group", func() {
+			dir := createEtcFiles()
+			defer os.RemoveAll(dir)
+			uid, gid, addgids, err := utils.GetUserInfo(dir, "300:mail")
+			Expect(err).To(BeNil())
+
+			// passwdFile should not be empty because an updated /etc/passwd file is created.
+			passwdFile, err := utils.GeneratePasswd(uid, gid, dir, dir)
+			Expect(err).To(BeNil())
+			Expect(passwdFile).To(Not(BeEmpty()))
+
+			// Double check that the uid, gid, and additional gids didn't change.
+			newuid, newgid, newaddgids, err := utils.GetUserInfo(dir, "300:mail")
+			Expect(err).To(BeNil())
+			Expect(newuid).To(Equal(uid))
+			Expect(newgid).To(Equal(gid))
+			Expect(newaddgids).To(Equal(addgids))
+		})
+	})
 })
+
+func createEtcFiles() string {
+	// Create an /etc/passwd and /etc/group file that match
+	// those of the alpine image
+	// This will be created in a temp directory like /tmp/uid-test*
+	alpinePasswdFile := `root:x:0:0:root:/root:/bin/ash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+news:x:9:13:news:/usr/lib/news:/sbin/nologin
+uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
+operator:x:11:0:operator:/root:/bin/sh
+man:x:13:15:man:/usr/man:/sbin/nologin
+postmaster:x:14:12:postmaster:/var/spool/mail:/sbin/nologin
+cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
+ftp:x:21:21::/var/lib/ftp:/sbin/nologin
+sshd:x:22:22:sshd:/dev/null:/sbin/nologin
+at:x:25:25:at:/var/spool/cron/atjobs:/sbin/nologin
+squid:x:31:31:Squid:/var/cache/squid:/sbin/nologin
+xfs:x:33:33:X Font Server:/etc/X11/fs:/sbin/nologin
+games:x:35:35:games:/usr/games:/sbin/nologin
+postgres:x:70:70::/var/lib/postgresql:/bin/sh
+cyrus:x:85:12::/usr/cyrus:/sbin/nologin
+vpopmail:x:89:89::/var/vpopmail:/sbin/nologin
+ntp:x:123:123:NTP:/var/empty:/sbin/nologin
+smmsp:x:209:209:smmsp:/var/spool/mqueue:/sbin/nologin
+guest:x:405:100:guest:/dev/null:/sbin/nologin
+nobody:x:65534:65534:nobody:/:/sbin/nologin`
+
+	alpineGroupFile := `root:x:0:root
+bin:x:1:root,bin,daemon
+daemon:x:2:root,bin,daemon
+sys:x:3:root,bin,adm
+adm:x:4:root,adm,daemon
+tty:x:5:
+disk:x:6:root,adm
+lp:x:7:lp
+mem:x:8:
+kmem:x:9:
+wheel:x:10:root
+floppy:x:11:root
+mail:x:12:mail
+news:x:13:news
+uucp:x:14:uucp
+man:x:15:man
+cron:x:16:cron
+console:x:17:
+audio:x:18:
+cdrom:x:19:
+dialout:x:20:root
+ftp:x:21:
+sshd:x:22:
+input:x:23:
+at:x:25:at
+tape:x:26:root
+video:x:27:root
+netdev:x:28:
+readproc:x:30:
+squid:x:31:squid
+xfs:x:33:xfs
+kvm:x:34:kvm
+games:x:35:
+shadow:x:42:
+postgres:x:70:
+cdrw:x:80:
+usb:x:85:
+vpopmail:x:89:
+users:x:100:games
+ntp:x:123:
+nofiles:x:200:
+smmsp:x:209:smmsp
+locate:x:245:
+abuild:x:300:
+utmp:x:406:
+ping:x:999:
+nogroup:x:65533:
+nobody:x:65534:`
+
+	dir, err := ioutil.TempDir("/tmp", "uid-test")
+	Expect(err).To(BeNil())
+	err = os.Mkdir(filepath.Join(dir, "etc"), 0755)
+	Expect(err).To(BeNil())
+	err = ioutil.WriteFile(filepath.Join(dir, "etc", "passwd"), []byte(alpinePasswdFile), 0755)
+	Expect(err).To(BeNil())
+	err = ioutil.WriteFile(filepath.Join(dir, "etc", "group"), []byte(alpineGroupFile), 0755)
+	Expect(err).To(BeNil())
+	return dir
+}

--- a/vendor/github.com/containers/libpod/pkg/lookup/lookup.go
+++ b/vendor/github.com/containers/libpod/pkg/lookup/lookup.go
@@ -1,0 +1,158 @@
+package lookup
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/cyphar/filepath-securejoin"
+	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	etcpasswd = "/etc/passwd"
+	etcgroup  = "/etc/group"
+)
+
+// Overrides allows you to override defaults in GetUserGroupInfo
+type Overrides struct {
+	DefaultUser            *user.ExecUser
+	ContainerEtcPasswdPath string
+	ContainerEtcGroupPath  string
+}
+
+// GetUserGroupInfo takes string forms of the the container's mount path and the container user and
+// returns a ExecUser with uid, gid, sgids, and home.  And override can be provided for defaults.
+func GetUserGroupInfo(containerMount, containerUser string, override *Overrides) (*user.ExecUser, error) {
+	var (
+		passwdDest, groupDest string
+		defaultExecUser       *user.ExecUser
+		err                   error
+	)
+	passwdPath := etcpasswd
+	groupPath := etcgroup
+
+	if override != nil {
+		// Check for an override /etc/passwd path
+		if override.ContainerEtcPasswdPath != "" {
+			passwdPath = override.ContainerEtcPasswdPath
+		}
+		// Check for an override for /etc/group path
+		if override.ContainerEtcGroupPath != "" {
+			groupPath = override.ContainerEtcGroupPath
+		}
+	}
+
+	// Check for an override default user
+	if override != nil && override.DefaultUser != nil {
+		defaultExecUser = override.DefaultUser
+	} else {
+		// Define a default container user
+		//defaultExecUser = &user.ExecUser{
+		//	Uid:  0,
+		//	Gid:  0,
+		//	Home: "/",
+		defaultExecUser = nil
+
+	}
+
+	// Make sure the /etc/group  and /etc/passwd destinations are not a symlink to something naughty
+	if passwdDest, err = securejoin.SecureJoin(containerMount, passwdPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+	if groupDest, err = securejoin.SecureJoin(containerMount, groupPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+	return user.GetExecUserPath(containerUser, defaultExecUser, passwdDest, groupDest)
+}
+
+// GetContainerGroups uses securejoin to get a list of numerical groupids from a container. Per the runc
+// function it calls: If a group name cannot be found, an error will be returned. If a group id cannot be found,
+// or the given group data is nil, the id will be returned as-is  provided it is in the legal range.
+func GetContainerGroups(groups []string, containerMount string, override *Overrides) ([]uint32, error) {
+	var (
+		groupDest string
+		err       error
+		uintgids  []uint32
+	)
+
+	groupPath := etcgroup
+	if override != nil && override.ContainerEtcGroupPath != "" {
+		groupPath = override.ContainerEtcGroupPath
+	}
+
+	if groupDest, err = securejoin.SecureJoin(containerMount, groupPath); err != nil {
+		logrus.Debug(err)
+		return nil, err
+	}
+
+	gids, err := user.GetAdditionalGroupsPath(groups, groupDest)
+	if err != nil {
+		return nil, err
+	}
+	// For libpod, we want []uint32s
+	for _, gid := range gids {
+		uintgids = append(uintgids, uint32(gid))
+	}
+	return uintgids, nil
+}
+
+// GetUser takes a containermount path and user name or id and returns
+// a matching User structure from /etc/passwd.  If it cannot locate a user
+// with the provided information, an ErrNoPasswdEntries is returned.
+func GetUser(containerMount, userIDorName string) (*user.User, error) {
+	var inputIsName bool
+	uid, err := strconv.Atoi(userIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+	passwdDest, err := securejoin.SecureJoin(containerMount, etcpasswd)
+	if err != nil {
+		return nil, err
+	}
+	users, err := user.ParsePasswdFileFilter(passwdDest, func(u user.User) bool {
+		if inputIsName {
+			return u.Name == userIDorName
+		}
+		return u.Uid == uid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(users) > 0 {
+		return &users[0], nil
+	}
+	return nil, user.ErrNoPasswdEntries
+}
+
+// GetGroup takes ac ontainermount path and a group name or id and returns
+// a match Group struct from /etc/group.  if it cannot locate a group,
+// an ErrNoGroupEntries error is returned.
+func GetGroup(containerMount, groupIDorName string) (*user.Group, error) {
+	var inputIsName bool
+	gid, err := strconv.Atoi(groupIDorName)
+	if err != nil {
+		inputIsName = true
+	}
+
+	groupDest, err := securejoin.SecureJoin(containerMount, etcgroup)
+	if err != nil {
+		return nil, err
+	}
+
+	groups, err := user.ParseGroupFileFilter(groupDest, func(g user.Group) bool {
+		if inputIsName {
+			return g.Name == groupIDorName
+		}
+		return g.Gid == gid
+	})
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(groups) > 0 {
+		return &groups[0], nil
+	}
+	return nil, user.ErrNoGroupEntries
+}


### PR DESCRIPTION
Create a new /etc/passwd in the container with a record for the
user account that is running the container.

This will allow getpwuid calls to succeed inside of the container.
We have seen failures where getpwduid was not successful.
Also vendor in an update libpod packages

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>
Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

Replaces #1841 