### PR TITLE
Update CNI config versions to 0.4.0

### DIFF
--- a/contrib/cni/10-crio-bridge.conf
+++ b/contrib/cni/10-crio-bridge.conf
@@ -1,5 +1,5 @@
 {
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.4.0",
     "name": "crio-bridge",
     "type": "bridge",
     "bridge": "cni0",

--- a/contrib/cni/99-loopback.conf
+++ b/contrib/cni/99-loopback.conf
@@ -1,4 +1,4 @@
 {
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.4.0",
     "type": "loopback"
 }


### PR DESCRIPTION
There is a conflicts with other CNI consumers where CRI-O's configuration files are causing the CNI plugins to fail to start because their versions are too low. Upgrading the plugin versions should resolve this conflict, and not cause any adverse effect to a typical CRI-O install.

https://github.com/containers/libpod/issues/454

cc @mheon