### PR TITLE
[1.11] Increase max grpc message size

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -519,7 +519,13 @@ func main() {
 			logrus.Fatalf("failed to listen: %v", err)
 		}
 
-		s := grpc.NewServer()
+		// The default grpc msg size is 4MB.
+		// We bump it up to 16MB for allowing more containers.
+		maxMsgSize := 16 * 1024 * 1024
+		s := grpc.NewServer(
+			grpc.MaxSendMsgSize(maxMsgSize),
+			grpc.MaxRecvMsgSize(maxMsgSize),
+		)
 
 		service, err := server.New(ctx, config)
 		if err != nil {


### PR DESCRIPTION
We hit a limit when there are a lot of containers running.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

Note: For the newer branches I will open PRs with this as a configuration option.

@giuseppe @runcom @rhatdan ptal.