### PR TITLE
Validate system registries configuration on start

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/containers/image/pkg/sysregistries"
+	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/containers/image/types"
 	"github.com/containers/libpod/pkg/spec"
 	"github.com/containers/storage"
@@ -513,6 +514,11 @@ version 1.14, this option will no longer exist.
 			}
 			logrus.Debugf("found valid runtime '%s' for runtime_path '%s'\n",
 				runtime, handler.RuntimePath)
+		}
+
+		// Validate the system registries configuration
+		if _, err := sysregistriesv2.GetRegistries(nil); err != nil {
+			return fmt.Errorf("invalid /etc/containers/registries.conf: %q", err)
 		}
 	}
 


### PR DESCRIPTION
This PR adds another runtime validation for the `/etc/containers/registries.conf`. The benefit is now that the user gets early feedback on cri-o start (for example if the user has mixed up the v1 and v2 syntax).

Currently this would only considered on image pull (which could be too late).

Beside that I have a question: Is it intended that we switch to sysregistriesv2 for `lib/config.go`? It should be possible since there is a backwards compatibility from v2 to v1, but would imply breaking changes within the configuration syntax of cri-o.