### PR TITLE
config: Add config options for setting grpc msg size max

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -75,6 +75,12 @@ stream_tls_key = "{{ .StreamTLSKey }}"
 # automatically pick up the changes within 5 minutes.
 stream_tls_ca = "{{ .StreamTLSCA }}"
 
+# Maximum grpc send message size in bytes. If not set or <=0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_send_msg_size = {{ .GRPCMaxSendMsgSize }}
+
+# Maximum grpc receive message size. If not set or <= 0, then CRI-O will default to 16 * 1024 * 1024.
+grpc_max_recv_msg_size = {{ .GRPCMaxRecvMsgSize }}
+
 # The crio.runtime table contains settings pertaining to the OCI runtime used
 # and options for how to set up and manage the OCI runtime.
 [crio.runtime]

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -516,6 +516,13 @@ func main() {
 			return err
 		}
 
+		if config.GRPCMaxSendMsgSize <= 0 {
+			config.GRPCMaxSendMsgSize = server.DefaultGRPCMaxMsgSize
+		}
+		if config.GRPCMaxRecvMsgSize <= 0 {
+			config.GRPCMaxRecvMsgSize = server.DefaultGRPCMaxMsgSize
+		}
+
 		if !config.SELinux {
 			disableSELinux()
 		}
@@ -535,7 +542,10 @@ func main() {
 			logrus.Fatalf("failed to listen: %v", err)
 		}
 
-		s := grpc.NewServer()
+		s := grpc.NewServer(
+			grpc.MaxSendMsgSize(config.GRPCMaxSendMsgSize),
+			grpc.MaxRecvMsgSize(config.GRPCMaxRecvMsgSize),
+		)
 
 		service, err := server.New(ctx, config)
 		if err != nil {

--- a/server/config.go
+++ b/server/config.go
@@ -10,6 +10,11 @@ import (
 	"github.com/kubernetes-sigs/cri-o/oci"
 )
 
+const (
+	// DefaultGRPCMaxMsgSize is the default message size maximum for grpc APIs.
+	DefaultGRPCMaxMsgSize = 16 * 1024 * 1024
+)
+
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {
@@ -19,6 +24,12 @@ type Config struct {
 
 // APIConfig represents the "crio.api" TOML config table.
 type APIConfig struct {
+	// GRPCMaxSendMsgSize is the maximum grpc send message size in bytes.
+	GRPCMaxSendMsgSize int `toml:"grpc_max_send_msg_size"`
+
+	// GRPCMaxRecvMsgSize is the maximum grpc receive message size in bytes.
+	GRPCMaxRecvMsgSize int `toml:"grpc_max_recv_msg_size"`
+
 	// Listen is the path to the AF_LOCAL socket on which cri-o will listen.
 	// This may support proto://addr formats later, but currently this is just
 	// a path.
@@ -116,9 +127,11 @@ func DefaultConfig() *Config {
 	return &Config{
 		Config: *lib.DefaultConfig(),
 		APIConfig: APIConfig{
-			Listen:        CrioSocketPath,
-			StreamAddress: "127.0.0.1",
-			StreamPort:    "0",
+			Listen:             CrioSocketPath,
+			StreamAddress:      "127.0.0.1",
+			StreamPort:         "0",
+			GRPCMaxSendMsgSize: DefaultGRPCMaxMsgSize,
+			GRPCMaxRecvMsgSize: DefaultGRPCMaxMsgSize,
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

@runcom @giuseppe ptal.