### PR TITLE
Fix apparmor related integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     iptables \
     pkg-config \
     libaio-dev \
+    libapparmor-dev \
     libcap-dev \
     libfuse-dev \
     libnet-dev \
@@ -67,7 +68,7 @@ RUN set -x \
 	&& cd "$GOPATH/src/github.com/opencontainers/runc" \
 	&& git fetch origin --tags \
 	&& git checkout -q "$RUNC_COMMIT" \
-	&& make static BUILDTAGS="seccomp selinux" \
+	&& make static BUILDTAGS="seccomp selinux apparmor" \
 	&& cp runc /usr/bin/runc \
 	&& rm -rf "$GOPATH"
 

--- a/test/apparmor.bats
+++ b/test/apparmor.bats
@@ -17,7 +17,7 @@ function teardown() {
 
     start_crio
 
-    sed -e 's/%VALUE%/,"container\.apparmor\.security\.beta\.kubernetes\.io\/testname1": "runtime\/default"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/apparmor1.json
+    sed -e 's/%VALUE%/runtime\/default/g' "$TESTDATA"/sandbox_config_apparmor.json > "$TESTDIR"/apparmor1.json
 
     run crictl runp "$TESTDIR"/apparmor1.json
     echo "$output"
@@ -48,19 +48,19 @@ function teardown() {
     load_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
     start_crio "" "$APPARMOR_TEST_PROFILE_NAME"
 
-    sed -e 's/%VALUE%/,"container\.apparmor\.security\.beta\.kubernetes\.io\/testname2": "apparmor-test-deny-write"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/apparmor2.json
+    sed -e 's/%VALUE%/apparmor-test-deny-write/g' "$TESTDATA"/sandbox_config_apparmor.json > "$TESTDIR"/apparmor2.json
+    sed -e 's/%VALUE%/apparmor-test-deny-write/g' "$TESTDATA"/container_redis_apparmor.json > "$TESTDIR"/apparmor_container2.json
 
     run crictl runp "$TESTDIR"/apparmor2.json
     echo "$output"
     [ "$status" -eq 0 ]
     pod_id="$output"
-    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/apparmor2.json
+    run crictl create "$pod_id" "$TESTDIR"/apparmor_container2.json "$TESTDIR"/apparmor2.json
     echo "$output"
     [ "$status" -eq 0 ]
     ctr_id="$output"
     run crictl exec --sync "$ctr_id" touch test.txt
     echo "$output"
-    [ "$status" -ne 0 ]
     [[ "$output" =~ "Permission denied" ]]
 
     cleanup_ctrs
@@ -81,19 +81,19 @@ function teardown() {
     load_apparmor_profile "$APPARMOR_TEST_PROFILE_PATH"
     start_crio
 
-    sed -e 's/%VALUE%/,"container\.apparmor\.security\.beta\.kubernetes\.io\/testname3": "apparmor-test-deny-write"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/apparmor3.json
+    sed -e 's/%VALUE%/apparmor-test-deny-write/g' "$TESTDATA"/sandbox_config_apparmor.json > "$TESTDIR"/apparmor3.json
+    sed -e 's/%VALUE%/apparmor-test-deny-write/g' "$TESTDATA"/container_redis_apparmor.json > "$TESTDIR"/apparmor_container3.json
 
     run crictl runp "$TESTDIR"/apparmor3.json
     echo "$output"
     [ "$status" -eq 0 ]
     pod_id="$output"
-    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/apparmor3.json
+    run crictl create "$pod_id" "$TESTDIR"/apparmor_container3.json "$TESTDIR"/apparmor3.json
     echo "$output"
     [ "$status" -eq 0 ]
     ctr_id="$output"
     run crictl exec --sync "$ctr_id" touch test.txt
     echo "$output"
-    [ "$status" -ne 0 ]
     [[ "$output" =~ "Permission denied" ]]
 
     cleanup_ctrs
@@ -103,7 +103,7 @@ function teardown() {
 }
 
 # 4. test running with wrong apparmor profile name.
-# test that we can will fail when running a ctr with rong apparmor profile name.
+# test that we can will fail when running a ctr with wrong apparmor profile name.
 @test "run a container with wrong apparmor profile name" {
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
@@ -113,13 +113,14 @@ function teardown() {
 
     start_crio
 
-    sed -e 's/%VALUE%/,"container\.apparmor\.security\.beta\.kubernetes\.io\/testname4": "not-exists"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/apparmor4.json
+    sed -e 's/%VALUE%/not-exists/g' "$TESTDATA"/sandbox_config_apparmor.json > "$TESTDIR"/apparmor4.json
+    sed -e 's/%VALUE%/not-exists/g' "$TESTDATA"/container_redis_apparmor.json > "$TESTDIR"/apparmor_container4.json
 
     run crictl runp "$TESTDIR"/apparmor4.json
     echo "$output"
     [ "$status" -eq 0 ]
     pod_id="$output"
-    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/apparmor4.json
+    run crictl create "$pod_id" "$TESTDIR"/apparmor_container4.json "$TESTDIR"/apparmor4.json
     echo "$output"
     [ "$status" -ne 0 ]
     [[ "$output" =~ "Creating container failed" ]]
@@ -130,7 +131,7 @@ function teardown() {
 }
 
 # 5. test running with default apparmor profile unloaded.
-# test that we can will fail when running a ctr with rong apparmor profile name.
+# test that we can will fail when running a ctr with wrong apparmor profile name.
 @test "run a container after unloading default apparmor profile" {
     # this test requires apparmor, so skip this test if apparmor is not enabled.
     enabled=$(is_apparmor_enabled)
@@ -141,19 +142,16 @@ function teardown() {
     start_crio
     remove_apparmor_profile "$FAKE_CRIO_DEFAULT_PROFILE_PATH"
 
-    sed -e 's/%VALUE%/,"container\.apparmor\.security\.beta\.kubernetes\.io\/testname5": "runtime\/default"/g' "$TESTDATA"/sandbox_config_seccomp.json > "$TESTDIR"/apparmor5.json
+    sed -e 's/%VALUE%/runtime\/default/g' "$TESTDATA"/sandbox_config_apparmor.json > "$TESTDIR"/apparmor5.json
+    sed -e 's/%VALUE%/runtime\/default/g' "$TESTDATA"/container_redis_apparmor.json > "$TESTDIR"/apparmor_container5.json
 
     run crictl runp "$TESTDIR"/apparmor5.json
     echo "$output"
     [ "$status" -eq 0 ]
     pod_id="$output"
-    run crictl create "$pod_id" "$TESTDATA"/container_redis.json "$TESTDIR"/apparmor5.json
+    run crictl create "$pod_id" "$TESTDIR"/apparmor_container5.json "$TESTDIR"/apparmor5.json
     echo "$output"
-    [ "$status" -eq 0 ]
-    ctr_id="$output"
-    run crictl exec --sync "$ctr_id" touch test.txt
-    echo "$output"
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
 
     cleanup_ctrs
     cleanup_pods

--- a/test/testdata/container_redis_apparmor.json
+++ b/test/testdata/container_redis_apparmor.json
@@ -1,0 +1,63 @@
+{
+  "metadata": {
+    "name": "podsandbox1-redis"
+  },
+  "image": {
+    "image": "quay.io/crio/redis:alpine"
+  },
+  "args": ["docker-entrypoint.sh", "redis-server"],
+  "working_dir": "/data",
+  "envs": [
+    {
+      "key": "PATH",
+      "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    },
+    {
+      "key": "TERM",
+      "value": "xterm"
+    },
+    {
+      "key": "REDIS_VERSION",
+      "value": "3.2.3"
+    },
+    {
+      "key": "REDIS_DOWNLOAD_URL",
+      "value": "http://download.redis.io/releases/redis-3.2.3.tar.gz"
+    },
+    {
+      "key": "REDIS_DOWNLOAD_SHA1",
+      "value": "92d6d93ef2efc91e595c8bf578bf72baff397507"
+    }
+  ],
+  "labels": {
+    "tier": "backend"
+  },
+  "annotations": {
+    "pod": "podsandbox1"
+  },
+  "readonly_rootfs": false,
+  "log_path": "",
+  "stdin": false,
+  "stdin_once": false,
+  "tty": false,
+  "linux": {
+    "resources": {
+      "memory_limit_in_bytes": 209715200,
+      "cpu_period": 10000,
+      "cpu_quota": 20000,
+      "cpu_shares": 512,
+      "oom_score_adj": 30,
+      "cpuset_cpus": "0",
+      "cpuset_mems": "0"
+    },
+    "security_context": {
+      "apparmor_profile": "%VALUE%",
+      "namespace_options": {
+        "pid": 1
+      },
+      "capabilities": {
+        "add_capabilities": ["sys_admin"]
+      }
+    }
+  }
+}

--- a/test/testdata/sandbox_config_apparmor.json
+++ b/test/testdata/sandbox_config_apparmor.json
@@ -1,0 +1,48 @@
+{
+  "metadata": {
+    "name": "podsandbox1",
+    "uid": "redhat-test-crio",
+    "namespace": "redhat.test.crio",
+    "attempt": 1
+  },
+  "hostname": "crictl_host",
+  "log_directory": "",
+  "dns_options": {
+    "servers": ["server1.redhat.com", "server2.redhat.com"],
+    "searches": ["8.8.8.8"]
+  },
+  "port_mappings": [],
+  "resources": {
+    "cpu": {
+      "limits": 3,
+      "requests": 2
+    },
+    "memory": {
+      "limits": 50000000,
+      "requests": 2000000
+    }
+  },
+  "labels": {
+    "group": "test"
+  },
+  "annotations": {
+    "owner": "hmeng"
+  },
+  "linux": {
+    "cgroup_parent": "/Burstable/pod_123-456",
+    "security_context": {
+      "apparmor_profile": "%VALUE%",
+      "namespace_options": {
+        "network": 0,
+        "pid": 1,
+        "ipc": 0
+      },
+      "selinux_options": {
+        "user": "system_u",
+        "role": "system_r",
+        "type": "svirt_lxc_net_t",
+        "level": "s0:c4,c5"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey, this PR fixes the apparmor related integration tests (currently disabled within the pipeline). I verified that it works with openSUSE Kubic. The main test appraoch changed a bit since it now uses the `apparmor_profile` field directly within the `security_context`. The plan is to run these tests later on a regular basis, too.

Closes #2040