### PR TITLE
[1.12] Add container description to conmon

### DIFF
--- a/oci/container.go
+++ b/oci/container.go
@@ -14,6 +14,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"k8s.io/apimachinery/pkg/fields"
 	pb "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -304,4 +305,9 @@ func (c *Container) SetCreated() {
 // Created returns whether the container was created successfully
 func (c *Container) Created() bool {
 	return c.created
+}
+
+// Description returns a description for the container
+func (c *Container) Description() string {
+	return fmt.Sprintf("%s/%s/%s", c.Labels()[types.KubernetesPodNamespaceLabel], c.Labels()[types.KubernetesPodNameLabel], c.Labels()[types.KubernetesContainerNameLabel])
 }

--- a/oci/oci_linux.go
+++ b/oci/oci_linux.go
@@ -18,7 +18,7 @@ func (r *Runtime) createContainerPlatform(c *Container, cgroupParent string, pid
 	// Move conmon to specified cgroup
 	if r.cgroupManager == SystemdCgroupsManager {
 		logrus.Debugf("Running conmon under slice %s and unitName %s", cgroupParent, createUnitName("crio-conmon", c.id))
-		if err := utils.RunUnderSystemdScope(pid, cgroupParent, createUnitName("crio-conmon", c.id)); err != nil {
+		if err := utils.RunUnderSystemdScope(pid, cgroupParent, createUnitName("crio-conmon", c.id), c.Description()); err != nil {
 			logrus.Warnf("Failed to add conmon to systemd sandbox cgroup: %v", err)
 		}
 		return nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -51,7 +51,7 @@ func StatusToExitCode(status int) int {
 }
 
 // RunUnderSystemdScope adds the specified pid to a systemd scope
-func RunUnderSystemdScope(pid int, slice string, unitName string) error {
+func RunUnderSystemdScope(pid int, slice string, unitName string, description string) error {
 	var properties []systemdDbus.Property
 	conn, err := systemdDbus.New()
 	if err != nil {
@@ -61,6 +61,7 @@ func RunUnderSystemdScope(pid int, slice string, unitName string) error {
 	properties = append(properties, newProp("PIDs", []uint32{uint32(pid)}))
 	properties = append(properties, newProp("Delegate", true))
 	properties = append(properties, newProp("DefaultDependencies", false))
+	properties = append(properties, newProp("Description", description))
 	ch := make(chan string)
 	_, err = conn.StartTransientUnit(unitName, "replace", properties, ch)
 	if err != nil {


### PR DESCRIPTION
Add a description of the form k8s namespaces/pod/container
for the conmon scope to make it easier to associate container IDs
to k8s objects for debugging.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

@giuseppe @vrothberg @umohnani8 @runcom ptal.