### PR TITLE
[release-1.12] contrib/systemd: add metrics env

### DIFF
--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -7,6 +7,7 @@ After=network-online.target
 Type=notify
 EnvironmentFile=-/etc/sysconfig/crio-storage
 EnvironmentFile=-/etc/sysconfig/crio-network
+EnvironmentFile=-/etc/sysconfig/crio-metrics
 Environment=GOTRACEBACK=crash
 ExecStart=/usr/local/bin/crio \
           $CRIO_STORAGE_OPTIONS \


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@linux.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Silly me, I swear this should be the last change we need to expose crio metrics. If I commit this change on an ocp 4 cluster and curl the metrics endpoint I can finally see them.
We'll need another 1.12 rebuild from @lsm5 

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
