### PR TITLE
Fix network test failure

### DIFF
--- a/test/network.bats
+++ b/test/network.bats
@@ -181,7 +181,7 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed after network setup
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
+	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
 	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }
@@ -195,7 +195,7 @@ function teardown() {
 
 	# ensure that the server cleaned up sandbox networking if the sandbox
 	# failed during network setup after the CNI plugin itself succeeded
-	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip
+	rm -f /var/lib/cni/networks/crionet_test_args/last_reserved_ip*
 	num_allocated=$(ls /var/lib/cni/networks/crionet_test_args | wc -l)
 	[[ "${num_allocated}" == "0" ]]
 }


### PR DESCRIPTION
Hey, this fix makes the network test a bit more robust. I encountered network names like `last_reserved_ip.0` which will cause the test to fail but should not harm the overall test result.