### PR TITLE
[1.12] Move config structs to pkg/config

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -21,6 +21,7 @@ import (
 	units "github.com/docker/go-units"
 	"github.com/kubernetes-sigs/cri-o/lib"
 	"github.com/kubernetes-sigs/cri-o/oci"
+	crioconfig "github.com/kubernetes-sigs/cri-o/pkg/config"
 	"github.com/kubernetes-sigs/cri-o/pkg/signals"
 	"github.com/kubernetes-sigs/cri-o/server"
 	"github.com/kubernetes-sigs/cri-o/utils"
@@ -75,9 +76,9 @@ func validateRuntimeConfig(config *server.Config) error {
 
 func validateConfig(config *server.Config) error {
 	switch config.ImageVolumes {
-	case lib.ImageVolumesMkdir:
-	case lib.ImageVolumesIgnore:
-	case lib.ImageVolumesBind:
+	case crioconfig.ImageVolumesMkdir:
+	case crioconfig.ImageVolumesIgnore:
+	case crioconfig.ImageVolumesBind:
 	default:
 		return fmt.Errorf("Unrecognized image volume type specified")
 	}
@@ -241,7 +242,7 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 		config.PluginDir = ctx.GlobalString("cni-plugin-dir")
 	}
 	if ctx.GlobalIsSet("image-volumes") {
-		config.ImageVolumes = lib.ImageVolumesType(ctx.GlobalString("image-volumes"))
+		config.ImageVolumes = crioconfig.ImageVolumesType(ctx.GlobalString("image-volumes"))
 	}
 	if ctx.GlobalIsSet("read-only") {
 		config.ReadOnly = ctx.GlobalBool("read-only")
@@ -455,7 +456,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "image-volumes",
-			Value: string(lib.ImageVolumesMkdir),
+			Value: string(crioconfig.ImageVolumesMkdir),
 			Usage: "image volume handling ('mkdir', 'bind', or 'ignore')",
 		},
 		cli.StringFlag{

--- a/lib/config.go
+++ b/lib/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containers/libpod/pkg/hooks"
 	"github.com/containers/storage"
 	"github.com/kubernetes-sigs/cri-o/oci"
+	"github.com/kubernetes-sigs/cri-o/pkg/config"
 )
 
 // Defaults if none are specified
@@ -24,23 +25,11 @@ const (
 // Config represents the entire set of configuration values that can be set for
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {
-	RootConfig
-	RuntimeConfig
-	ImageConfig
-	NetworkConfig
+	config.RootConfig
+	config.RuntimeConfig
+	config.ImageConfig
+	config.NetworkConfig
 }
-
-// ImageVolumesType describes image volume handling strategies
-type ImageVolumesType string
-
-const (
-	// ImageVolumesMkdir option is for using mkdir to handle image volumes
-	ImageVolumesMkdir ImageVolumesType = "mkdir"
-	// ImageVolumesIgnore option is for ignoring image volumes altogether
-	ImageVolumesIgnore ImageVolumesType = "ignore"
-	// ImageVolumesBind option is for using bind mounted volumes
-	ImageVolumesBind ImageVolumesType = "bind"
-)
 
 const (
 	// DefaultPidsLimit is the default value for maximum number of processes
@@ -67,233 +56,15 @@ var DefaultCapabilities = []string{
 	"KILL",
 }
 
-// This structure is necessary to fake the TOML tables when parsing,
-// while also not requiring a bunch of layered structs for no good
-// reason.
-
-// RootConfig represents the root of the "crio" TOML config table.
-type RootConfig struct {
-	// Root is a path to the "root directory" where data not
-	// explicitly handled by other options will be stored.
-	Root string `toml:"root"`
-
-	// RunRoot is a path to the "run directory" where state information not
-	// explicitly handled by other options will be stored.
-	RunRoot string `toml:"runroot"`
-
-	// Storage is the name of the storage driver which handles actually
-	// storing the contents of containers.
-	Storage string `toml:"storage_driver"`
-
-	// StorageOption is a list of storage driver specific options.
-	StorageOptions []string `toml:"storage_option"`
-
-	// LogDir is the default log directory were all logs will go unless kubelet
-	// tells us to put them somewhere else.
-	LogDir string `toml:"log_dir"`
-
-	// FileLocking specifies whether to use file-based or in-memory locking
-	// File-based locking is required when multiple users of lib are
-	// present on the same system
-	FileLocking bool `toml:"file_locking"`
-
-	// FileLockingPath specifies the path to use for the locking.
-	FileLockingPath string `toml:"file_locking_path"`
-}
-
-// RuntimeConfig represents the "crio.runtime" TOML config table.
-type RuntimeConfig struct {
-	// Runtime is the OCI compatible runtime used for trusted container workloads.
-	// This is a mandatory setting as this runtime will be the default one and
-	// will also be used for untrusted container workloads if
-	// RuntimeUntrustedWorkload is not set.
-	//
-	// DEPRECATED: use Runtimes instead.
-	//
-	Runtime string `toml:"runtime"`
-
-	// DefaultRuntime is the _name_ of the OCI runtime to be used as the default.
-	// The name is matched against the Runtimes map below.
-	DefaultRuntime string `toml:"default_runtime"`
-
-	// RuntimeUntrustedWorkload is the OCI compatible runtime used for
-	// untrusted container workloads. This is an optional setting, except
-	// if DefaultWorkloadTrust is set to "untrusted".
-	// DEPRECATED: use Runtimes instead. If provided, this runtime is
-	//     mapped to the runtime handler named 'untrusted'. It is a
-	//     configuration error to provide both the (now deprecated)
-	//     RuntimeUntrustedWorkload and a handler in the Runtimes handler
-	//     map (below) for 'untrusted' workloads at the same time. Please
-	//     provide one or the other.
-	//     The support of this option will continue through versions 1.12 and 1.13.
-	//     By version 1.14, this option will no longer exist.
-	RuntimeUntrustedWorkload string `toml:"runtime_untrusted_workload"`
-
-	// DefaultWorkloadTrust is the default level of trust crio puts in container
-	// workloads. This can either be "trusted" or "untrusted" and the default
-	// is "trusted"
-	// Containers can be run through different container runtimes, depending on
-	// the trust hints we receive from kubelet:
-	// - If kubelet tags a container workload as untrusted, crio will try first
-	// to run it through the untrusted container workload runtime. If it is not
-	// set, crio will use the trusted runtime.
-	// - If kubelet does not provide any information about the container workload trust
-	// level, the selected runtime will depend on the DefaultWorkloadTrust setting.
-	// If it is set to "untrusted", then all containers except for the host privileged
-	// ones, will be run by the RuntimeUntrustedWorkload runtime. Host privileged
-	// containers are by definition trusted and will always use the trusted container
-	// runtime. If DefaultWorkloadTrust is set to "trusted", crio will use the trusted
-	// container runtime for all containers.
-	// DEPRECATED: The runtime handler should provide a key to the map of runtimes,
-	//     avoiding the need to rely on the level of trust of the workload to choose
-	//     an appropriate runtime.
-	//     The support of this option will continue through versions 1.12 and 1.13.
-	//     By version 1.14, this option will no longer exist.
-	DefaultWorkloadTrust string `toml:"default_workload_trust"`
-
-	// Runtimes defines a list of OCI compatible runtimes. The runtime to
-	// use is picked based on the runtime_handler provided by the CRI. If
-	// no runtime_handler is provided, the runtime will be picked based on
-	// the level of trust of the workload.
-	Runtimes map[string]oci.RuntimeHandler `toml:"runtimes"`
-
-	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
-	NoPivot bool `toml:"no_pivot"`
-
-	// Conmon is the path to conmon binary, used for managing the runtime.
-	Conmon string `toml:"conmon"`
-
-	// ConmonEnv is the environment variable list for conmon process.
-	ConmonEnv []string `toml:"conmon_env"`
-
-	// SELinux determines whether or not SELinux is used for pod separation.
-	SELinux bool `toml:"selinux"`
-
-	// SeccompProfile is the seccomp json profile path which is used as the
-	// default for the runtime.
-	SeccompProfile string `toml:"seccomp_profile"`
-
-	// ApparmorProfile is the apparmor profile name which is used as the
-	// default for the runtime.
-	ApparmorProfile string `toml:"apparmor_profile"`
-
-	// CgroupManager is the manager implementation name which is used to
-	// handle cgroups for containers.
-	CgroupManager string `toml:"cgroup_manager"`
-
-	// HooksDirPath location of oci hooks config files
-	HooksDirPath string `toml:"hooks_dir_path"`
-
-	// DefaultMounts is the list of mounts to be mounted for each container
-	// The format of each mount is "host-path:container-path"
-	DefaultMounts []string `toml:"default_mounts"`
-
-	// DefaultMountsFile is the file path for the default mounts to be mounted for the container
-	// Note, for testing purposes mainly
-	DefaultMountsFile string `toml:"default_mounts_file"`
-
-	// PidsLimit is the number of processes each container is restricted to
-	// by the cgroup process number controller.
-	PidsLimit int64 `toml:"pids_limit"`
-
-	// LogSizeMax is the maximum number of bytes after which the log file
-	// will be truncated. It can be expressed as a human-friendly string
-	// that is parsed to bytes.
-	// Negative values indicate that the log file won't be truncated.
-	LogSizeMax int64 `toml:"log_size_max"`
-
-	// ContainerExitsDir is the directory in which container exit files are
-	// written to by conmon.
-	ContainerExitsDir string `toml:"container_exits_dir"`
-
-	// ContainerAttachSocketDir is the location for container attach sockets.
-	ContainerAttachSocketDir string `toml:"container_attach_socket_dir"`
-
-	// ManageNetworkNSLifecycle determines whether we pin and remove network namespace
-	// and manage its lifecycle
-	ManageNetworkNSLifecycle bool `toml:"manage_network_ns_lifecycle"`
-
-	// ReadOnly run all pods/containers in read-only mode.
-	// This mode will mount tmpfs on /run, /tmp and /var/tmp, if those are not mountpoints
-	// Will also set the readonly flag in the OCI Runtime Spec.  In this mode containers
-	// will only be able to write to volumes mounted into them
-	ReadOnly bool `toml:"read_only"`
-
-	// BindMountPrefix is the prefix to use for the source of the bind mounts.
-	BindMountPrefix string `toml:"bind_mount_prefix"`
-
-	// UIDMappings specifies the UID mappings to have in the user namespace.
-	// A range is specified in the form containerUID:HostUID:Size.  Multiple
-	// ranges are separed by comma.
-	UIDMappings string `toml:"uid_mappings"`
-
-	// GIDMappings specifies the GID mappings to have in the user namespace.
-	// A range is specified in the form containerUID:HostUID:Size.  Multiple
-	// ranges are separed by comma.
-	GIDMappings string `toml:"gid_mappings"`
-
-	// Capabilities to add to all containers.
-	DefaultCapabilities []string `toml:"default_capabilities"`
-
-	// LogLevel determines the verbosity of the logs based on the level it is set to.
-	// Options are fatal, panic, error (default), warn, info, and debug.
-	LogLevel string `toml:"log_level"`
-
-	// CtrStopTimeout specifies the time to wait before to generate an
-	// error because the container state is still tagged as "running".
-	CtrStopTimeout int64 `toml:"ctr_stop_timeout"`
-
-	// Sysctls to add to all containers.
-	DefaultSysctls []string `toml:"default_sysctls"`
-
-	// DefeultUlimits specifies the default ulimits to apply to containers
-	DefaultUlimits []string `toml:"default_ulimits"`
-}
-
-// ImageConfig represents the "crio.image" TOML config table.
-type ImageConfig struct {
-	// DefaultTransport is a value we prefix to image names that fail to
-	// validate source references.
-	DefaultTransport string `toml:"default_transport"`
-	// PauseImage is the name of an image which we use to instantiate infra
-	// containers.
-	PauseImage string `toml:"pause_image"`
-	// PauseCommand is the path of the binary we run in an infra
-	// container that's been instantiated using PauseImage.
-	PauseCommand string `toml:"pause_command"`
-	// SignaturePolicyPath is the name of the file which decides what sort
-	// of policy we use when deciding whether or not to trust an image that
-	// we've pulled.  Outside of testing situations, it is strongly advised
-	// that this be left unspecified so that the default system-wide policy
-	// will be used.
-	SignaturePolicyPath string `toml:"signature_policy"`
-	// InsecureRegistries is a list of registries that must be contacted w/o
-	// TLS verification.
-	InsecureRegistries []string `toml:"insecure_registries"`
-	// ImageVolumes controls how volumes specified in image config are handled
-	ImageVolumes ImageVolumesType `toml:"image_volumes"`
-	// Registries holds a list of registries used to pull unqualified images
-	Registries []string `toml:"registries"`
-}
-
-// NetworkConfig represents the "crio.network" TOML config table
-type NetworkConfig struct {
-	// NetworkDir is where CNI network configuration files are stored.
-	NetworkDir string `toml:"network_dir"`
-
-	// PluginDir is where CNI plugin binaries are stored.
-	PluginDir string `toml:"plugin_dir"`
-}
-
 // tomlConfig is another way of looking at a Config, which is
 // TOML-friendly (it has all of the explicit tables). It's just used for
 // conversions.
 type tomlConfig struct {
 	Crio struct {
-		RootConfig
-		Runtime struct{ RuntimeConfig } `toml:"runtime"`
-		Image   struct{ ImageConfig }   `toml:"image"`
-		Network struct{ NetworkConfig } `toml:"network"`
+		config.RootConfig
+		Runtime struct{ config.RuntimeConfig } `toml:"runtime"`
+		Image   struct{ config.ImageConfig }   `toml:"image"`
+		Network struct{ config.NetworkConfig } `toml:"network"`
 	} `toml:"crio"`
 }
 
@@ -354,7 +125,7 @@ func DefaultConfig() *Config {
 	registries, _ := sysregistries.GetRegistries(&types.SystemContext{})
 	insecureRegistries, _ := sysregistries.GetInsecureRegistries(&types.SystemContext{})
 	return &Config{
-		RootConfig: RootConfig{
+		RootConfig: config.RootConfig{
 			Root:            storage.DefaultStoreOptions.GraphRoot,
 			RunRoot:         storage.DefaultStoreOptions.RunRoot,
 			Storage:         storage.DefaultStoreOptions.GraphDriverName,
@@ -363,7 +134,7 @@ func DefaultConfig() *Config {
 			FileLocking:     true,
 			FileLockingPath: lockPath,
 		},
-		RuntimeConfig: RuntimeConfig{
+		RuntimeConfig: config.RuntimeConfig{
 			DefaultRuntime: "runc",
 			Runtimes: map[string]oci.RuntimeHandler{
 				"runc": {
@@ -388,16 +159,16 @@ func DefaultConfig() *Config {
 			DefaultSysctls:           []string{},
 			DefaultUlimits:           []string{},
 		},
-		ImageConfig: ImageConfig{
+		ImageConfig: config.ImageConfig{
 			DefaultTransport:    defaultTransport,
 			PauseImage:          pauseImage,
 			PauseCommand:        pauseCommand,
 			SignaturePolicyPath: "",
-			ImageVolumes:        ImageVolumesMkdir,
+			ImageVolumes:        config.ImageVolumesMkdir,
 			Registries:          registries,
 			InsecureRegistries:  insecureRegistries,
 		},
-		NetworkConfig: NetworkConfig{
+		NetworkConfig: config.NetworkConfig{
 			NetworkDir: cniConfigDir,
 			PluginDir:  cniBinDir,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,268 @@
+package config
+
+import (
+	"github.com/kubernetes-sigs/cri-o/oci"
+)
+
+// ImageVolumesType describes image volume handling strategies
+type ImageVolumesType string
+
+const (
+	// ImageVolumesMkdir option is for using mkdir to handle image volumes
+	ImageVolumesMkdir ImageVolumesType = "mkdir"
+	// ImageVolumesIgnore option is for ignoring image volumes altogether
+	ImageVolumesIgnore ImageVolumesType = "ignore"
+	// ImageVolumesBind option is for using bind mounted volumes
+	ImageVolumesBind ImageVolumesType = "bind"
+)
+
+// This structure is necessary to fake the TOML tables when parsing,
+// while also not requiring a bunch of layered structs for no good
+// reason.
+
+// RootConfig represents the root of the "crio" TOML config table.
+type RootConfig struct {
+	// Root is a path to the "root directory" where data not
+	// explicitly handled by other options will be stored.
+	Root string `toml:"root"`
+
+	// RunRoot is a path to the "run directory" where state information not
+	// explicitly handled by other options will be stored.
+	RunRoot string `toml:"runroot"`
+
+	// Storage is the name of the storage driver which handles actually
+	// storing the contents of containers.
+	Storage string `toml:"storage_driver"`
+
+	// StorageOption is a list of storage driver specific options.
+	StorageOptions []string `toml:"storage_option"`
+
+	// LogDir is the default log directory were all logs will go unless kubelet
+	// tells us to put them somewhere else.
+	LogDir string `toml:"log_dir"`
+
+	// FileLocking specifies whether to use file-based or in-memory locking
+	// File-based locking is required when multiple users of lib are
+	// present on the same system
+	FileLocking bool `toml:"file_locking"`
+
+	// FileLockingPath specifies the path to use for the locking.
+	FileLockingPath string `toml:"file_locking_path"`
+}
+
+// RuntimeConfig represents the "crio.runtime" TOML config table.
+type RuntimeConfig struct {
+	// Runtime is the OCI compatible runtime used for trusted container workloads.
+	// This is a mandatory setting as this runtime will be the default one and
+	// will also be used for untrusted container workloads if
+	// RuntimeUntrustedWorkload is not set.
+	//
+	// DEPRECATED: use Runtimes instead.
+	//
+	Runtime string `toml:"runtime"`
+
+	// DefaultRuntime is the _name_ of the OCI runtime to be used as the default.
+	// The name is matched against the Runtimes map below.
+	DefaultRuntime string `toml:"default_runtime"`
+
+	// RuntimeUntrustedWorkload is the OCI compatible runtime used for
+	// untrusted container workloads. This is an optional setting, except
+	// if DefaultWorkloadTrust is set to "untrusted".
+	// DEPRECATED: use Runtimes instead. If provided, this runtime is
+	//     mapped to the runtime handler named 'untrusted'. It is a
+	//     configuration error to provide both the (now deprecated)
+	//     RuntimeUntrustedWorkload and a handler in the Runtimes handler
+	//     map (below) for 'untrusted' workloads at the same time. Please
+	//     provide one or the other.
+	//     The support of this option will continue through versions 1.12 and 1.13.
+	//     By version 1.14, this option will no longer exist.
+	RuntimeUntrustedWorkload string `toml:"runtime_untrusted_workload"`
+
+	// DefaultWorkloadTrust is the default level of trust crio puts in container
+	// workloads. This can either be "trusted" or "untrusted" and the default
+	// is "trusted"
+	// Containers can be run through different container runtimes, depending on
+	// the trust hints we receive from kubelet:
+	// - If kubelet tags a container workload as untrusted, crio will try first
+	// to run it through the untrusted container workload runtime. If it is not
+	// set, crio will use the trusted runtime.
+	// - If kubelet does not provide any information about the container workload trust
+	// level, the selected runtime will depend on the DefaultWorkloadTrust setting.
+	// If it is set to "untrusted", then all containers except for the host privileged
+	// ones, will be run by the RuntimeUntrustedWorkload runtime. Host privileged
+	// containers are by definition trusted and will always use the trusted container
+	// runtime. If DefaultWorkloadTrust is set to "trusted", crio will use the trusted
+	// container runtime for all containers.
+	// DEPRECATED: The runtime handler should provide a key to the map of runtimes,
+	//     avoiding the need to rely on the level of trust of the workload to choose
+	//     an appropriate runtime.
+	//     The support of this option will continue through versions 1.12 and 1.13.
+	//     By version 1.14, this option will no longer exist.
+	DefaultWorkloadTrust string `toml:"default_workload_trust"`
+
+	// Runtimes defines a list of OCI compatible runtimes. The runtime to
+	// use is picked based on the runtime_handler provided by the CRI. If
+	// no runtime_handler is provided, the runtime will be picked based on
+	// the level of trust of the workload.
+	Runtimes map[string]oci.RuntimeHandler `toml:"runtimes"`
+
+	// NoPivot instructs the runtime to not use `pivot_root`, but instead use `MS_MOVE`
+	NoPivot bool `toml:"no_pivot"`
+
+	// Conmon is the path to conmon binary, used for managing the runtime.
+	Conmon string `toml:"conmon"`
+
+	// ConmonEnv is the environment variable list for conmon process.
+	ConmonEnv []string `toml:"conmon_env"`
+
+	// SELinux determines whether or not SELinux is used for pod separation.
+	SELinux bool `toml:"selinux"`
+
+	// SeccompProfile is the seccomp json profile path which is used as the
+	// default for the runtime.
+	SeccompProfile string `toml:"seccomp_profile"`
+
+	// ApparmorProfile is the apparmor profile name which is used as the
+	// default for the runtime.
+	ApparmorProfile string `toml:"apparmor_profile"`
+
+	// CgroupManager is the manager implementation name which is used to
+	// handle cgroups for containers.
+	CgroupManager string `toml:"cgroup_manager"`
+
+	// HooksDirPath location of oci hooks config files
+	HooksDirPath string `toml:"hooks_dir_path"`
+
+	// DefaultMounts is the list of mounts to be mounted for each container
+	// The format of each mount is "host-path:container-path"
+	DefaultMounts []string `toml:"default_mounts"`
+
+	// DefaultMountsFile is the file path for the default mounts to be mounted for the container
+	// Note, for testing purposes mainly
+	DefaultMountsFile string `toml:"default_mounts_file"`
+
+	// PidsLimit is the number of processes each container is restricted to
+	// by the cgroup process number controller.
+	PidsLimit int64 `toml:"pids_limit"`
+
+	// LogSizeMax is the maximum number of bytes after which the log file
+	// will be truncated. It can be expressed as a human-friendly string
+	// that is parsed to bytes.
+	// Negative values indicate that the log file won't be truncated.
+	LogSizeMax int64 `toml:"log_size_max"`
+
+	// ContainerExitsDir is the directory in which container exit files are
+	// written to by conmon.
+	ContainerExitsDir string `toml:"container_exits_dir"`
+
+	// ContainerAttachSocketDir is the location for container attach sockets.
+	ContainerAttachSocketDir string `toml:"container_attach_socket_dir"`
+
+	// ManageNetworkNSLifecycle determines whether we pin and remove network namespace
+	// and manage its lifecycle
+	ManageNetworkNSLifecycle bool `toml:"manage_network_ns_lifecycle"`
+
+	// ReadOnly run all pods/containers in read-only mode.
+	// This mode will mount tmpfs on /run, /tmp and /var/tmp, if those are not mountpoints
+	// Will also set the readonly flag in the OCI Runtime Spec.  In this mode containers
+	// will only be able to write to volumes mounted into them
+	ReadOnly bool `toml:"read_only"`
+
+	// BindMountPrefix is the prefix to use for the source of the bind mounts.
+	BindMountPrefix string `toml:"bind_mount_prefix"`
+
+	// UIDMappings specifies the UID mappings to have in the user namespace.
+	// A range is specified in the form containerUID:HostUID:Size.  Multiple
+	// ranges are separed by comma.
+	UIDMappings string `toml:"uid_mappings"`
+
+	// GIDMappings specifies the GID mappings to have in the user namespace.
+	// A range is specified in the form containerUID:HostUID:Size.  Multiple
+	// ranges are separed by comma.
+	GIDMappings string `toml:"gid_mappings"`
+
+	// Capabilities to add to all containers.
+	DefaultCapabilities []string `toml:"default_capabilities"`
+
+	// LogLevel determines the verbosity of the logs based on the level it is set to.
+	// Options are fatal, panic, error (default), warn, info, and debug.
+	LogLevel string `toml:"log_level"`
+
+	// CtrStopTimeout specifies the time to wait before to generate an
+	// error because the container state is still tagged as "running".
+	CtrStopTimeout int64 `toml:"ctr_stop_timeout"`
+
+	// Sysctls to add to all containers.
+	DefaultSysctls []string `toml:"default_sysctls"`
+
+	// DefeultUlimits specifies the default ulimits to apply to containers
+	DefaultUlimits []string `toml:"default_ulimits"`
+}
+
+// ImageConfig represents the "crio.image" TOML config table.
+type ImageConfig struct {
+	// DefaultTransport is a value we prefix to image names that fail to
+	// validate source references.
+	DefaultTransport string `toml:"default_transport"`
+	// PauseImage is the name of an image which we use to instantiate infra
+	// containers.
+	PauseImage string `toml:"pause_image"`
+	// PauseCommand is the path of the binary we run in an infra
+	// container that's been instantiated using PauseImage.
+	PauseCommand string `toml:"pause_command"`
+	// SignaturePolicyPath is the name of the file which decides what sort
+	// of policy we use when deciding whether or not to trust an image that
+	// we've pulled.  Outside of testing situations, it is strongly advised
+	// that this be left unspecified so that the default system-wide policy
+	// will be used.
+	SignaturePolicyPath string `toml:"signature_policy"`
+	// InsecureRegistries is a list of registries that must be contacted w/o
+	// TLS verification.
+	InsecureRegistries []string `toml:"insecure_registries"`
+	// ImageVolumes controls how volumes specified in image config are handled
+	ImageVolumes ImageVolumesType `toml:"image_volumes"`
+	// Registries holds a list of registries used to pull unqualified images
+	Registries []string `toml:"registries"`
+}
+
+// NetworkConfig represents the "crio.network" TOML config table
+type NetworkConfig struct {
+	// NetworkDir is where CNI network configuration files are stored.
+	NetworkDir string `toml:"network_dir"`
+
+	// PluginDir is where CNI plugin binaries are stored.
+	PluginDir string `toml:"plugin_dir"`
+}
+
+// APIConfig represents the "crio.api" TOML config table.
+type APIConfig struct {
+	// GRPCMaxSendMsgSize is the maximum grpc send message size in bytes.
+	GRPCMaxSendMsgSize int `toml:"grpc_max_send_msg_size"`
+
+	// GRPCMaxRecvMsgSize is the maximum grpc receive message size in bytes.
+	GRPCMaxRecvMsgSize int `toml:"grpc_max_recv_msg_size"`
+
+	// Listen is the path to the AF_LOCAL socket on which cri-o will listen.
+	// This may support proto://addr formats later, but currently this is just
+	// a path.
+	Listen string `toml:"listen"`
+
+	// StreamAddress is the IP address on which the stream server will listen.
+	StreamAddress string `toml:"stream_address"`
+
+	// StreamPort is the port on which the stream server will listen.
+	StreamPort string `toml:"stream_port"`
+
+	// StreamEnableTLS enables encrypted tls transport of the stream server
+	StreamEnableTLS bool `toml:"stream_enable_tls"`
+
+	// StreamTLSCert is the x509 certificate file path used to serve the encrypted stream
+	StreamTLSCert string `toml:"stream_tls_cert"`
+
+	// StreamTLSKey is the key file path used to serve the encrypted stream
+	StreamTLSKey string `toml:"stream_tls_key"`
+
+	// StreamTLSCA is the x509 CA(s) file used to verify and authenticate client
+	// communication with the tls encrypted stream
+	StreamTLSCA string `toml:"stream_tls_ca"`
+}

--- a/server/config.go
+++ b/server/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/kubernetes-sigs/cri-o/lib"
+	"github.com/kubernetes-sigs/cri-o/pkg/config"
 )
 
 const (
@@ -17,40 +18,7 @@ const (
 // the server. This is intended to be loaded from a toml-encoded config file.
 type Config struct {
 	lib.Config
-	APIConfig
-}
-
-// APIConfig represents the "crio.api" TOML config table.
-type APIConfig struct {
-	// GRPCMaxSendMsgSize is the maximum grpc send message size in bytes.
-	GRPCMaxSendMsgSize int `toml:"grpc_max_send_msg_size"`
-
-	// GRPCMaxRecvMsgSize is the maximum grpc receive message size in bytes.
-	GRPCMaxRecvMsgSize int `toml:"grpc_max_recv_msg_size"`
-
-	// Listen is the path to the AF_LOCAL socket on which cri-o will listen.
-	// This may support proto://addr formats later, but currently this is just
-	// a path.
-	Listen string `toml:"listen"`
-
-	// StreamAddress is the IP address on which the stream server will listen.
-	StreamAddress string `toml:"stream_address"`
-
-	// StreamPort is the port on which the stream server will listen.
-	StreamPort string `toml:"stream_port"`
-
-	// StreamEnableTLS enables encrypted tls transport of the stream server
-	StreamEnableTLS bool `toml:"stream_enable_tls"`
-
-	// StreamTLSCert is the x509 certificate file path used to serve the encrypted stream
-	StreamTLSCert string `toml:"stream_tls_cert"`
-
-	// StreamTLSKey is the key file path used to serve the encrypted stream
-	StreamTLSKey string `toml:"stream_tls_key"`
-
-	// StreamTLSCA is the x509 CA(s) file used to verify and authenticate client
-	// communication with the tls encrypted stream
-	StreamTLSCA string `toml:"stream_tls_ca"`
+	config.APIConfig
 }
 
 // tomlConfig is another way of looking at a Config, which is
@@ -58,11 +26,11 @@ type APIConfig struct {
 // conversions.
 type tomlConfig struct {
 	Crio struct {
-		lib.RootConfig
-		API     struct{ APIConfig }         `toml:"api"`
-		Runtime struct{ lib.RuntimeConfig } `toml:"runtime"`
-		Image   struct{ lib.ImageConfig }   `toml:"image"`
-		Network struct{ lib.NetworkConfig } `toml:"network"`
+		config.RootConfig
+		API     struct{ config.APIConfig }     `toml:"api"`
+		Runtime struct{ config.RuntimeConfig } `toml:"runtime"`
+		Image   struct{ config.ImageConfig }   `toml:"image"`
+		Network struct{ config.NetworkConfig } `toml:"network"`
 	} `toml:"crio"`
 }
 
@@ -124,7 +92,7 @@ func (c *Config) ToFile(path string) error {
 func DefaultConfig() *Config {
 	return &Config{
 		Config: *lib.DefaultConfig(),
-		APIConfig: APIConfig{
+		APIConfig: config.APIConfig{
 			Listen:             CrioSocketPath,
 			StreamAddress:      "127.0.0.1",
 			StreamPort:         "0",

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/kubernetes-sigs/cri-o/lib"
+	"github.com/kubernetes-sigs/cri-o/pkg/config"
 )
 
 const fixturePath = "fixtures/crio.conf"
@@ -38,7 +38,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.ImageConfig.PauseImage, "kubernetes/pause"},
 		{c.ImageConfig.PauseCommand, "/pause"},
 		{c.ImageConfig.SignaturePolicyPath, "/tmp"},
-		{c.ImageConfig.ImageVolumes, lib.ImageVolumesType("mkdir")},
+		{c.ImageConfig.ImageVolumes, config.ImageVolumesType("mkdir")},
 		{c.ImageConfig.InsecureRegistries[0], "insecure-registry:1234"},
 		{c.ImageConfig.Registries[0], "registry:4321"},
 

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -13,8 +13,8 @@ import (
 	dockermounts "github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
-	"github.com/kubernetes-sigs/cri-o/lib"
 	"github.com/kubernetes-sigs/cri-o/lib/sandbox"
+	"github.com/kubernetes-sigs/cri-o/pkg/config"
 	"github.com/kubernetes-sigs/cri-o/pkg/seccomp"
 	"github.com/kubernetes-sigs/cri-o/pkg/storage"
 	"github.com/opencontainers/image-spec/specs-go/v1"
@@ -164,11 +164,11 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 			return nil, err
 		}
 		switch s.config.ImageVolumes {
-		case lib.ImageVolumesMkdir:
+		case config.ImageVolumesMkdir:
 			if err1 := os.MkdirAll(fp, 0755); err1 != nil {
 				return nil, err1
 			}
-		case lib.ImageVolumesBind:
+		case config.ImageVolumesBind:
 			volumeDirName := stringid.GenerateNonCryptoID()
 			src := filepath.Join(containerInfo.RunDir, "mounts", volumeDirName)
 			if err1 := os.MkdirAll(src, 0755); err1 != nil {
@@ -189,7 +189,7 @@ func addImageVolumes(rootfs string, s *Server, containerInfo *storage.ContainerI
 				Options:     []string{"private", "bind", "rw"},
 			})
 
-		case lib.ImageVolumesIgnore:
+		case config.ImageVolumesIgnore:
 			logrus.Debugf("Ignoring volume %v", dest)
 		default:
 			logrus.Fatalf("Unrecognized image volumes setting")

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-sigs/cri-o/pkg/config"
+
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	"github.com/kubernetes-sigs/cri-o/lib"
@@ -17,7 +19,7 @@ func TestGetInfo(t *testing.T) {
 	c.RootConfig.Storage = "afoobarstorage"
 	c.RootConfig.Root = "afoobarroot"
 	c.RuntimeConfig.CgroupManager = "systemd"
-	apiConfig := APIConfig{}
+	apiConfig := config.APIConfig{}
 	s := &Server{
 		config: Config{*c, apiConfig},
 	}


### PR DESCRIPTION
Need to use these structs in the CRD and controller
for container runtime config. Moving the structs to
a separate package to reduce dependencies.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
