### PR TITLE
Add codecov coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+---
+codecov:
+  notify:
+    after_n_builds: 1
+    require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: 50..75
+
+  status:
+    project: true
+    patch: true
+    changes: false
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
     - script:
         - make testunit
         - make
+        - make codecov
       go: "1.11.x"
     - script:
         - make local-cross

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,10 @@ mockgen: ${BUILD_BIN_PATH}/mockgen
 		-destination ${MOCK_PATH}/criostorage/criostorage.go \
 		github.com/kubernetes-sigs/cri-o/pkg/storage ImageServer
 
+codecov: SHELL := $(shell which bash)
+codecov:
+	bash <(curl -s https://codecov.io/bash) -f ${COVERAGE_PATH}/coverprofile
+
 localintegration: clean binaries test-binaries
 	./test/test_runner.sh ${TESTFLAGS}
 


### PR DESCRIPTION
I added codecov unit test coverage reports. Currently the bot is not able to comment since we have nothing to compare (master). The current coverage can be retrieved here: https://codecov.io/gh/kubernetes-sigs/cri-o