### PR TITLE
crio.conf.5.md formatting

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -6,7 +6,7 @@
 crio.conf - configuration file of the CRI-O OCI Kubernetes Container Runtime daemon
 
 # DESCRIPTION
-The CRI-O configuration file specifies all of the available configuration options and command-line flags for the crio(8) OCI Kubernetes Container Runtime daemon, but in a TOML format that can be more easily modified and versioned.
+The CRI-O configuration file specifies all of the available configuration options and command-line flags for the [crio(8) OCI Kubernetes Container Runtime daemon][crio], but in a TOML format that can be more easily modified and versioned.
 
 The default crio.conf is located at /etc/crio/crio.conf.
 
@@ -157,7 +157,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   Maximum number of processes allowed in a container.
 
 **log_size_max**=-1
-  Maximum sized allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer. The file is truncated and re-opened so the limit is never exceeded.
+  Maximum size allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer. The file is truncated and re-opened so the limit is never exceeded.
 
 **container_exits_dir**="/var/run/crio/exits"
   Path to directory in which container exit files are written to by conmon.
@@ -224,3 +224,6 @@ containers-storage.conf(5), containers-policy.json(5), containers-registries.con
 Aug 2018, Update to the latest state by Valentin Rothberg <vrothberg@suse.com>
 
 Oct 2016, Originally compiled by Aleksa Sarai <asarai@suse.de>
+
+[toml]: https://github.com/toml-lang/toml
+[crio]: ./crio.8.md

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -25,91 +25,92 @@ The [TOML format][toml] is used as the encoding of the configuration file. Every
 ## CRIO TABLE
 CRI-O reads its storage defaults from the containers-storage.conf(5) file located at /etc/containers/storage.conf. Modify this storage configuration if you want to change the system's defaults. If you want to modify storage just for CRI-O, you can change the storage configuration options here.
 
-**root**="/var/lib/containers/storage"
+**root**="/var/lib/containers/storage"\
   Path to the "root directory". CRI-O stores all of its data, including containers images, in this directory.
 
-**runroot**="/var/run/containers/storage"
+**runroot**="/var/run/containers/storage"\
   Path to the "run directory". CRI-O stores all of its state in this directory.
 
-**storage_driver**="overlay"
+**storage_driver**="overlay"\
   Storage driver used to manage the storage of images and containers. Please refer to containers-storage.conf(5) to see all available storage drivers.
 
-**storage_option**=[]
+**storage_option**=[]\
   List to pass options to the storage driver. Please refer to containers-storage.conf(5) to see all available storage options.
 
-**file_locking**=true
+**file_locking**=true\
   If set to false, in-memory locking will be used instead of file-based locking.
 
-**file_locking_path**="/runc/crio.lock"
+**file_locking_path**="/runc/crio.lock"\
   Path to the lock file.
 
 
 ## CRIO.API TABLE
 The `crio.api` table contains settings for the kubelet/gRPC interface.
 
-**listen**="/var/run/crio/crio.sock"
+**listen**="/var/run/crio/crio.sock"\
   Path to AF_LOCAL socket on which CRI-O will listen.
 
-**stream_address**="127.0.0.1"
+**stream_address**="127.0.0.1"\
   IP address on which the stream server will listen.
 
-**stream_port**="0"
+**stream_port**="0"\
   The port on which the stream server will listen.
 
-**stream_enable_tls**=false
+**stream_enable_tls**=false\
   Enable encrypted TLS transport of the stream server.
 
-**stream_tls_cert**=""
+**stream_tls_cert**=""\
   Path to the x509 certificate file used to serve the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
 
-**stream_tls_key**=""
+**stream_tls_key**=""\
   Path to the key file used to serve the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
 
-**stream_tls_ca**=""
+**stream_tls_ca**=""\
   Path to the x509 CA(s) file used to verify and authenticate client communication with the encrypted stream. This file can change, and CRI-O will automatically pick up the changes within 5 minutes.
 
 
 ## CRIO.RUNTIME TABLE
 The `crio.runtime` table contains settings pertaining to the OCI runtime used and options for how to set up and manage the OCI runtime.
 
-**runtime**="/usr/bin/runc"
+**runtime**="/usr/bin/runc"\
   Path to the OCI compatible runtime used for trusted container workloads. This is a mandatory setting as this runtime will be the default and will also be used for untrusted container workloads if `runtime_untrusted_workload` is not set.
 
-**runtime_untrusted_workload**=""
+**runtime_untrusted_workload**=""\
   Path to OCI compatible runtime used for untrusted container workloads. This is an optional setting, except if `default_container_trust` is set to "untrusted".
 
-**default_workload_trust**="trusted"
+**default_workload_trust**="trusted"\
   Default level of trust CRI-O puts in container workloads. It can either be "trusted" or "untrusted", and the default is "trusted". Containers can be run through different container runtimes, depending on the trust hints we receive from kubelet:
 
     - If kubelet tags a container workload as untrusted, CRI-O will try first to run it through the untrusted container workload runtime. If it is not set, CRI-O will use the trusted runtime.
 
     - If kubelet does not provide any information about the container workload trust level, the selected runtime will depend on the default_container_trust setting. If it is set to untrusted, then all containers except for the host privileged ones, will be run by the runtime_untrusted_workload runtime. Host privileged containers are by definition trusted and will always use the trusted container runtime. If default_container_trust is set to "trusted", CRI-O will use the trusted container runtime for all containers.
 
-**no_pivot**=*false*
+**no_pivot**=*false*\
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
 
-**conmon**="/usr/local/libexec/crio/conmon"
+**conmon**="/usr/local/libexec/crio/conmon"\
   Path to the conmon binary, used for monitoring the OCI runtime.
 
-**conmon_env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+**conmon_env**=["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]\
   Environment variable list for the conmon process, used for passing necessary environment variables to conmon or the runtime.
 
-**selinux**=false
+**selinux**=false\
   If true, SELinux will be used for pod separation on the host.
 
-**seccomp_profile**="/etc/crio/seccomp.json"
+**seccomp_profile**="/etc/crio/seccomp.json"\
   Path to the seccomp.json profile which is used as the default seccomp profile for the runtime.
 
-**apparmor_profile**=""
+**apparmor_profile**=""\
   Used to change the name of the default AppArmor profile of CRI-O. The default profile name is "crio-default-" followed by the version string of CRI-O.
 
-**cgroup_manager**="cgroupfs"
+**cgroup_manager**="cgroupfs"\
   Cgroup management implementation used for the runtime.
 
-**default_capabilities**=[]
+**default_capabilities**=[]\
   List of default capabilities for containers. If it is empty or commented out, only the capabilities defined in the container json file by the user/kube will be added.
 
   The default list is:
+
 ```
   default_capabilities = [
           "CHOWN",
@@ -126,13 +127,13 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   ]
 ```
 
-**default_sysctls**=[]
+**default_sysctls**=[]\
  List of default sysctls. If it is empty or commented out, only the sysctls defined in the container json file by the user/kube will be added.
 
-**additional_devices**=[]
+**additional_devices**=[]\
   List of additional devices. If it is empty or commented out, only the devices defined in the container json file by the user/kube will be added.
 
-**hooks_dir**=["*path*", ...]
+**hooks_dir**=["*path*", ...]\
   Each `*.json` file in the path configures a hook for CRI-O containers.  For more details on the syntax of the JSON files and the semantics of hook injection, see `oci-hooks(5)`.  CRI-O currently support both the 1.0.0 and 0.1.0 hook schemas, although the 0.1.0 schema is deprecated.
 
   Paths listed later in the array higher precedence (`oci-hooks(5)` discusses directory precedence).
@@ -143,41 +144,41 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
 
   If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/oci/hooks.d` and `/etc/containers/oci/hooks.d` in order of increasing precedence.  Using these defaults is deprecated, and callers should migrate to explicitly setting `hooks_dir`.
 
-**default_mounts**=[]
+**default_mounts**=[]\
   List of default mounts for each container. **Deprecated:** this option will be removed in future versions in favor of `default_mounts_file`.
 
-**default_mounts_file**="/etc/containers/mounts.conf"
+**default_mounts_file**="/etc/containers/mounts.conf"\
   Path to the file specifying the defaults mounts for each container. The format of the config is /SRC:/DST, one mount per line. Notice that CRI-O reads its default mounts from the following two files:
 
     1) `/etc/containers/mounts.conf` (i.e., default_mounts_file): This is the override file, where users can either add in their own default mounts, or override the default mounts shipped with the package.
 
     2) `/usr/share/containers/mounts.conf`: This is the default file read for mounts. If you want CRI-O to read from a different, specific mounts file, you can change the default_mounts_file. Note, if this is done, CRI-O will only add mounts it finds in this file.
 
-**pids_limit**=1024
+**pids_limit**=1024\
   Maximum number of processes allowed in a container.
 
-**log_size_max**=-1
+**log_size_max**=-1\
   Maximum size allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer. The file is truncated and re-opened so the limit is never exceeded.
 
-**container_exits_dir**="/var/run/crio/exits"
+**container_exits_dir**="/var/run/crio/exits"\
   Path to directory in which container exit files are written to by conmon.
 
-**container_attach_socket_dir**="/var/run/crio"
+**container_attach_socket_dir**="/var/run/crio"\
   Path to directory for container attach sockets.
 
-**read_only**=false
+**read_only**=false\
   If set to true, all containers will run in read-only mode.
 
-**log_level**="error"
+**log_level**="error"\
   Changes the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug.
 
-**uid_mappings**=""
+**uid_mappings**=""\
   The UID mappings for the user namespace of each container. A range is specified in the form containerUID:HostUID:Size. Multiple ranges must be separated by comma.
 
-**gid_mappings**=""
+**gid_mappings**=""\
   The GID mappings for the user namespace of each container. A range is specified in the form containerGID:HostGID:Size. Multiple ranges must be separated by comma.
 
-**ctr_stop_timeout**=10
+**ctr_stop_timeout**=10\
   The minimal amount of time in seconds to wait before issuing a timeout regarding the proper termination of the container.
 
 
@@ -186,35 +187,35 @@ The `crio.image` table contains settings pertaining to the management of OCI ima
 
 CRI-O reads its configured registries defaults from the system wide containers-registries.conf(5) located in /etc/containers/registries.conf. If you want to modify just CRI-O, you can change the registries configuration in this file. Otherwise, leave `insecure_registries` and `registries` commented out to use the system's defaults from /etc/containers/registries.conf.
 
-**default_transport**="docker://"
+**default_transport**="docker://"\
   Default transport for pulling images from a remote container storage.
 
-**pause_image**="k8s.gcr.io/pause:3.1"
+**pause_image**="k8s.gcr.io/pause:3.1"\
   The image used to instantiate infra containers.
 
-**pause_command**="/pause"
+**pause_command**="/pause"\
   The command to run to have a container stay in the paused state.
 
-**signature_policy**="/etc/containers/policy.json"
+**signature_policy**="/etc/containers/policy.json"\
   Path to the file which decides what sort of policy we use when deciding whether or not to trust an image that we've pulled. It is not recommended that this option be used, as the default behavior of using the system-wide default policy (i.e., /etc/containers/policy.json) is most often preferred. Please refer to containers-policy.json(5) for more details.
 
-**image_volumes**="mkdir"
+**image_volumes**="mkdir"\
   Controls how image volumes are handled. The valid values are mkdir, bind and ignore; the latter will ignore volumes entirely.
 
-**insecure_registries**=[]
+**insecure_registries**=[]\
   List of registries to skip TLS verification for pulling images.
 
-**registries**=["docker.io"]
+**registries**=["docker.io"]\
   List of registries to be used when pulling an unqualified image (e.g., "alpine:latest"). By default, registries is set to "docker.io" for compatibility reasons. Depending on your workload and usecase you may add more registries (e.g., "quay.io", "registry.fedoraproject.org", "registry.opensuse.org", etc.).
 
 
 ## CRIO.NETWORK TABLE
 The `crio.network` table containers settings pertaining to the management of CNI plugins.
 
-**network_dir**="/etc/cni/net.d/"
+**network_dir**="/etc/cni/net.d/"\
   Path to the directory where CNI configuration files are located.
 
-**plugin_dir**="/opt/cni/bin/"
+**plugin_dir**="/opt/cni/bin/"\
   Path to directory where CNI plugin binaries are located.
 
 # SEE ALSO


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* I tried to improve the crio.conf.5 markdown documentation
* I added a link to toml and crio.8 documentation
* I added newlines after the options as intended in the source document

**- How I did it**

* Adding markdown link references
* for the newline, added a backslash at the end of some lines

**- How to verify it**

* I looked at the diff
* I looked at the new rendering of the md at https://github.com/petervandenabeele/cri-o/blob/crio-conf-5-formatting/docs/crio.conf.5.md  (as opposed to the original at https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md )

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Improved formatting of crio.conf.5.md documentation.