### PR TITLE
Tests the output of ctr stats is not empty

### DIFF
--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -11,18 +11,13 @@ func GetDiskUsageStats(path string) (uint64, uint64, error) {
 	var dirSize, inodeCount uint64
 
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		fileStat, error := os.Lstat(path)
-		if error != nil {
-			if fileStat.Mode()&os.ModeSymlink != 0 {
-				// Is a symlink; no error should be returned
-				return nil
-			}
-			return error
+		if err != nil {
+			return err
 		}
-
-		dirSize += uint64(info.Size())
 		inodeCount++
-
+		if info != nil {
+			dirSize += uint64(info.Size())
+		}
 		return nil
 	})
 


### PR DESCRIPTION
Follow #2050, this PR add test to check each column of the output of `ListContainerStats` is not empty
Signed-off-by: Qi Wang <qiwan@redhat.com>

