### PR TITLE
journald log driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
     libdevmapper-dev \
     libgpgme11-dev \
     liblzma-dev \
+    libsystemd-dev \
     netcat \
     socat \
     --no-install-recommends \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,6 +88,7 @@ Vagrant.configure("2") do |config|
       ostree-devel \
       pkgconfig \
       runc \
+      systemd-devel \
       skopeo-containers
     chown vagrant:vagrant -R /home/vagrant
     modprobe overlay

--- a/conmon/Makefile
+++ b/conmon/Makefile
@@ -5,12 +5,12 @@ all: ../bin/conmon
 src = $(wildcard *.c)
 obj = $(src:.c=.o)
 
-override LIBS += $(shell pkg-config --libs glib-2.0)
+override LIBS += $(shell pkg-config --libs glib-2.0 libsystemd)
 
 VERSION = $(shell sed -n -e 's/^const Version = "\([^"]*\)"/\1/p' ../version/version.go)
 
 CFLAGS ?= -std=c99 -Os -Wall -Wextra
-override CFLAGS += $(shell pkg-config --cflags glib-2.0) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
+override CFLAGS += $(shell pkg-config --cflags glib-2.0 libsystemd) -DVERSION=\"$(VERSION)\" -DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 config.h: ../oci/oci.go
 	$(MAKE) -C .. conmon/config.h

--- a/contrib/test/integration/system.yml
+++ b/contrib/test/integration/system.yml
@@ -55,6 +55,7 @@
     - sed
     - skopeo-containers
     - socat
+    - systemd-devel
     - tar
     - wget
   async: '{{ 20 * 60 }}'


### PR DESCRIPTION
Laid groundwork for journald log driver, including:
Changed the log-path to allow for a colon delimited <DRIVER>:<PATH>, with two options for the <DRIVER>:
    kubernetes-log-file: Write output to <PATH> logs in kubernetes .log format
    journald: Write output to journald, and ignore <PATH>
if there is no colon in the log-path, the driver will be kubernetes-log-file to maintain backwards compatibility

Made changes where the log path was assumed to be set, as that assumption is no longer correct. For instance, we don't attempt to open the log_fd, nor attempt to call write_k8s_log

Adding PR here to allow for CI to run against it (per @giuseppe 's suggestion). As of now, this is just a conmon change, and not a change with CRI-O, so the functionality isn't wired all together yet.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
