### PR TITLE
[1.11] Drop the external git repo

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -39,14 +39,6 @@
     path: "{{ artifacts }}"
     state: directory
 
-- name: Add repo for new version of git
-  yum_repository:
-    name: Wandisco
-    description: Wandisco git repo (Added by Ansible from e2e.yml)
-    baseurl: http://opensource.wandisco.com/rhel/7Server/git/$basearch
-    gpgcheck: no
-  when: ansible_distribution in ['RedHat']
-
 - name: upgrade git package
   yum:
     name: 'git'


### PR DESCRIPTION
It doesn't have dependencies leading to failures at installation time.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

