### PR TITLE
Docs : crio-conf-5 formatting

### DIFF
--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -6,7 +6,7 @@
 crio.conf - configuration file of the CRI-O OCI Kubernetes Container Runtime daemon
 
 # DESCRIPTION
-The CRI-O configuration file specifies all of the available configuration options and command-line flags for the crio(8) OCI Kubernetes Container Runtime daemon, but in a TOML format that can be more easily modified and versioned.
+The CRI-O configuration file specifies all of the available configuration options and command-line flags for the [crio(8) OCI Kubernetes Container Runtime daemon][crio], but in a TOML format that can be more easily modified and versioned.
 
 The default crio.conf is located at /etc/crio/crio.conf.
 
@@ -157,7 +157,7 @@ The `crio.runtime` table contains settings pertaining to the OCI runtime used an
   Maximum number of processes allowed in a container.
 
 **log_size_max**=-1
-  Maximum sized allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer. The file is truncated and re-opened so the limit is never exceeded.
+  Maximum size allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer. The file is truncated and re-opened so the limit is never exceeded.
 
 **container_exits_dir**="/var/run/crio/exits"
   Path to directory in which container exit files are written to by conmon.
@@ -224,3 +224,6 @@ containers-storage.conf(5), containers-policy.json(5), containers-registries.con
 Aug 2018, Update to the latest state by Valentin Rothberg <vrothberg@suse.com>
 
 Oct 2016, Originally compiled by Aleksa Sarai <asarai@suse.de>
+
+[toml]: https://github.com/toml-lang/toml
+[crio]: ./crio.8.md


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

* I tried to improve the crio.conf.5 markdown documentation
* I added a link to toml and crio.8 documentation
* ~I added newlines after the options as intended in the source document~
  I reverted this commit because it breaks man page rendering

**- How I did it**

* Adding markdown link references
* ~for the missing newlines, added a backslash at the end of some lines~
  (reverted)

**- How to verify it**

* validate the diff
* look at the rendered version at
https://github.com/petervandenabeele/cri-o/blob/docs-crio-conf-5-formatting/docs/crio.conf.5.md  
and compare it with the "previous" version at
https://github.com/kubernetes-sigs/cri-o/blob/master/docs/crio.conf.5.md

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix links of crio.conf.5 documentation