### PR TITLE
Always set gid if returned from container user files

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -289,12 +289,13 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 	logrus.Debugf("CONTAINER USER: %+v", containerUser)
 
 	// Add uid, gid and groups from user
-	uid, _, addGroups, err := getUserInfo(rootfs, containerUser)
+	uid, gid, addGroups, err := getUserInfo(rootfs, containerUser)
 	if err != nil {
 		return err
 	}
 
 	specgen.SetProcessUID(uid)
+	specgen.SetProcessGID(gid)
 	if sc.GetRunAsGroup() != nil {
 		specgen.SetProcessGID(uint32(sc.GetRunAsGroup().GetValue()))
 	}


### PR DESCRIPTION
Image user could have a gid that we were skipping.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

