### PR TITLE
server: delete the container if it cannot be restored

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -153,12 +153,14 @@ func (s *Server) restore() {
 	}
 	pods := map[string]*storage.RuntimeContainerMetadata{}
 	podContainers := map[string]*storage.RuntimeContainerMetadata{}
+	names := map[string][]string{}
 	for _, container := range containers {
 		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(container.ID)
 		if err2 != nil {
 			logrus.Warnf("error parsing metadata for %s: %v, ignoring", container.ID, err2)
 			continue
 		}
+		names[container.ID] = container.Names
 		if metadata.Pod {
 			pods[container.ID] = &metadata
 		} else {
@@ -168,11 +170,17 @@ func (s *Server) restore() {
 	for containerID, metadata := range pods {
 		if err = s.LoadSandbox(containerID); err != nil {
 			logrus.Warnf("could not restore sandbox %s container %s: %v", metadata.PodID, containerID, err)
+			for _, n := range names[containerID] {
+				s.Store().DeleteContainer(n)
+			}
 		}
 	}
 	for containerID := range podContainers {
 		if err := s.LoadContainer(containerID); err != nil {
 			logrus.Warnf("could not restore container %s: %v", containerID, err)
+			for _, n := range names[containerID] {
+				s.Store().DeleteContainer(n)
+			}
 		}
 	}
 	// Restore sandbox IPs


### PR DESCRIPTION
If a pod or a container could not be restored, then delete them
from the storage.

Since the container was present in the storage and CRI-O didn't report
it to the the Kubelet, we would have failed the request from the
Kubelet to re-create it over and over again.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1677509

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 67639b573b059fa55635794bcacb557b4909b327)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
