### PR TITLE
test: Switch to golang 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 # libseccomp in jessie is not _quite_ new enough -- need backports version
 RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -50,7 +50,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.11.3"
+          version: "1.12"
     - name: clone build and install cri-o
       include: "build/cri-o.yml"
   post_tasks:


### PR DESCRIPTION
We can handle travis in a follow-on. 
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

