### PR TITLE
conmon: close the stdin on EOF if not tty

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -935,7 +935,7 @@ static gboolean conn_sock_cb(int fd, GIOCondition condition, gpointer user_data)
 	/* End of input */
 	conn_sock_shutdown(sock, SHUT_RD);
 	if (masterfd_stdin >= 0 && opt_stdin) {
-		if (!opt_leave_stdin_open) {
+		if (!opt_leave_stdin_open || !opt_terminal) {
 			close(masterfd_stdin);
 			masterfd_stdin = -1;
 		} else {


### PR DESCRIPTION
if we receive EOF when reading from stdin and we are not using a tty,
ignore opt_leave_stdin_open and close immediately the master stdin
fd.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1624041

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
