### PR TITLE
Pause credentials 1.12

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -263,6 +263,10 @@ default_transport = "{{ .DefaultTransport }}"
 # The image used to instantiate infra containers.
 pause_image = "{{ .PauseImage }}"
 
+# If not empty, the path to a docker/config.json-like file containing credentials
+# necessary for pulling the image specified by pause_image above.
+pause_image_auth_file = "{{ .PauseImageAuthFile }}"
+
 # The command to run to have a container stay in the paused state.
 pause_command = "{{ .PauseCommand }}"
 

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -145,6 +145,9 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("pause-image") {
 		config.PauseImage = ctx.GlobalString("pause-image")
 	}
+	if ctx.GlobalIsSet("pause-image-auth-file") {
+		config.PauseImageAuthFile = ctx.GlobalString("pause-image-auth-file")
+	}
 	if ctx.GlobalIsSet("signature-policy") {
 		config.SignaturePolicyPath = ctx.GlobalString("signature-policy")
 	}
@@ -369,6 +372,10 @@ func main() {
 		cli.StringFlag{
 			Name:  "pause-image",
 			Usage: "name of the pause image",
+		},
+		cli.StringFlag{
+			Name:  "pause-image-auth-file",
+			Usage: "path to a config file containing credentials for --pause-image",
 		},
 		cli.StringFlag{
 			Name:  "signature-policy",

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -26,6 +26,7 @@ crio
 [--log-level value]
 [--pause-command=[value]]
 [--pause-image=[value]]
+[--pause-image-auth-file=[value]]
 [--read-only]
 [--registry=[value]]
 [--root=[value]]
@@ -117,6 +118,8 @@ If `hooks_dir` is unset, CRI-O will currently default to `/usr/share/containers/
 **--pause-command**="": Path to the pause executable in the pause image (default: "/pause")
 
 **--pause-image**="": Image which contains the pause executable (default: "kubernetes/pause")
+
+**--pause-image-auth-file**="": Path to a config file containing credentials for --pause-image (default: "")
 
 **--pids-limit**="": Maximum number of processes allowed in a container (default: 1024)
 

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -195,6 +195,9 @@ CRI-O reads its configured registries defaults from the system wide containers-r
 **pause_image**="k8s.gcr.io/pause:3.1"
   The image used to instantiate infra containers.
 
+**pause_image_auth_file**=""
+ If not empty, the path to a docker/config.json-like file containing credentials necessary for pulling the image specified by pause_image above.
+
 **pause_command**="/pause"
   The command to run to have a container stay in the paused state.
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -160,6 +160,7 @@ func DefaultConfig() *Config {
 		ImageConfig: config.ImageConfig{
 			DefaultTransport:    defaultTransport,
 			PauseImage:          pauseImage,
+			PauseImageAuthFile:  "",
 			PauseCommand:        pauseCommand,
 			SignaturePolicyPath: "",
 			ImageVolumes:        config.ImageVolumesMkdir,

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -124,7 +124,7 @@ func New(ctx context.Context, config *Config) (*ContainerServer, error) {
 		return nil, err
 	}
 
-	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage)
+	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage, config.PauseImageAuthFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -210,6 +210,9 @@ type ImageConfig struct {
 	// PauseImage is the name of an image which we use to instantiate infra
 	// containers.
 	PauseImage string `toml:"pause_image"`
+	// PauseImageAuthFile, if not empty, is a path to a docker/config.json-like
+	// file containing credentials necessary for pulling PauseImage
+	PauseImageAuthFile string `toml:"pause_image_auth_file"`
 	// PauseCommand is the path of the binary we run in an infra
 	// container that's been instantiated using PauseImage.
 	PauseCommand string `toml:"pause_command"`

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -6,14 +6,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/containers/image/copy"
 	istorage "github.com/containers/image/storage"
 	"github.com/containers/image/transports/alltransports"
 	"github.com/containers/image/types"
 	"github.com/containers/storage"
 	cstorage "github.com/containers/storage"
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -72,7 +71,7 @@ type RuntimeServer interface {
 	// both its pod's ID and its container ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
 	// omitted, but not both.  All other arguments are required.
-	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings, copyOptions *copy.Options) (ContainerInfo, error)
+	CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings) (ContainerInfo, error)
 	// RemovePodSandbox deletes a pod sandbox's infrastructure container.
 	// The CRI expects that a sandbox can't be removed unless its only
 	// container is its infrastructure container, but we don't enforce that
@@ -87,7 +86,7 @@ type RuntimeServer interface {
 	// CreateContainer creates a container with the specified ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
 	// omitted, but not both.  All other arguments are required.
-	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings, copyOptions *copy.Options) (ContainerInfo, error)
+	CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error)
 	// DeleteContainer deletes a container, unmounting it first if need be.
 	DeleteContainer(idOrName string) error
 
@@ -147,7 +146,7 @@ func (metadata *RuntimeContainerMetadata) SetMountLabel(mountLabel string) {
 	metadata.MountLabel = mountLabel
 }
 
-func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings, options *copy.Options) (ContainerInfo, error) {
+func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, uid, namespace string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error) {
 	var ref types.ImageReference
 	if podName == "" || podID == "" {
 		return ContainerInfo{}, ErrInvalidPodName
@@ -188,7 +187,7 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 			return ContainerInfo{}, ErrInvalidImageName
 		}
 		logrus.Debugf("couldn't find image %q, retrieving it", image)
-		ref, err = r.storageImageServer.PullImage(systemContext, image, options)
+		ref, err = r.storageImageServer.PullImage(systemContext, image, nil)
 		if err != nil {
 			return ContainerInfo{}, err
 		}
@@ -330,12 +329,12 @@ func (r *runtimeService) createContainerOrPodSandbox(systemContext *types.System
 	}, nil
 }
 
-func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings, copyOptions *copy.Options) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, podID, metadataName, uid, namespace, attempt, "", idMappings, copyOptions)
+func (r *runtimeService) CreatePodSandbox(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, metadataName, uid, namespace string, attempt uint32, idMappings *idtools.IDMappings) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, podID, metadataName, uid, namespace, attempt, "", idMappings)
 }
 
-func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings, copyOptions *copy.Options) (ContainerInfo, error) {
-	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, "", "", attempt, mountLabel, idMappings, copyOptions)
+func (r *runtimeService) CreateContainer(systemContext *types.SystemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName string, attempt uint32, mountLabel string, idMappings *idtools.IDMappings) (ContainerInfo, error) {
+	return r.createContainerOrPodSandbox(systemContext, podName, podID, imageName, imageID, containerName, containerID, metadataName, "", "", attempt, mountLabel, idMappings)
 }
 
 func (r *runtimeService) RemovePodSandbox(idOrName string) error {

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -36,6 +36,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 
 		{c.ImageConfig.DefaultTransport, "docker://"},
 		{c.ImageConfig.PauseImage, "kubernetes/pause"},
+		{c.ImageConfig.PauseImageAuthFile, "/var/lib/kubelet/config.json"},
 		{c.ImageConfig.PauseCommand, "/pause"},
 		{c.ImageConfig.SignaturePolicyPath, "/tmp"},
 		{c.ImageConfig.ImageVolumes, config.ImageVolumesType("mkdir")},

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -744,8 +744,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 		metaname,
 		attempt,
 		mountLabel,
-		containerIDMappings,
-		nil)
+		containerIDMappings)
 	if err != nil {
 		return nil, err
 	}

--- a/server/fixtures/crio.conf
+++ b/server/fixtures/crio.conf
@@ -25,6 +25,7 @@ ctr_stop_timeout = 10
 [crio.image]
 default_transport = "docker://"
 pause_image = "kubernetes/pause"
+pause_image_auth_file = "/var/lib/kubelet/config.json"
 pause_command = "/pause"
 signature_policy = "/tmp"
 image_volumes = "mkdir"

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -106,8 +106,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		req.GetConfig().GetMetadata().GetUid(),
 		namespace,
 		attempt,
-		s.defaultIDMappings,
-		nil)
+		s.defaultIDMappings)
 	if errors.Cause(err) == storage.ErrDuplicateName {
 		return nil, fmt.Errorf("pod sandbox with name %q already exists", name)
 	}


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/cri-o/pull/2115 for the `master` version of this PR.

**- What I did**

Added support for supplying credentials necessary for pulling the pause image.

**- How I did it**

Added a `pause_image_auth_file` config option, and a corresponding `--pause-image-auth-file` CLI option.

They are disabled by default, preserving the current behavior. Users have to opt in by explicitly pointing at a config file.

**- How to verify it**

Ultimately, run with `--pause-image-auth-file` in the CLI, or the `pause_image_auth_file` option (I didn’t do that yet.)

The `master` version of this PR has GoMock-based tests; this branch does not use GoMock, so this PR does not add them.

**- Description for the changelog**

New config and CLI options allow supplying credentials necessary for pulling the pause image.