### PR TITLE
[master] Allow device mounting to work in privileged mode

### DIFF
--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -71,9 +71,24 @@ func addDevicesPlatform(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig
 				Access: "rwm",
 			},
 		}
-		return nil
 	}
+
 	for _, device := range containerConfig.GetDevices() {
+		// If we are privileged, we have access to devices on the host.
+		// If the requested container path already exists on the host, the container won't see the expected host path.
+		// Therefore, we must error out if the container path already exists
+		privileged := containerConfig.GetLinux().GetSecurityContext() != nil && containerConfig.GetLinux().GetSecurityContext().GetPrivileged()
+		if privileged && device.ContainerPath != device.HostPath {
+			// we expect this to not exist
+			_, err := os.Stat(device.ContainerPath)
+			if err == nil {
+				return errors.Errorf("privileged container was configured with a device container path that already exists on the host.")
+			}
+			if !os.IsNotExist(err) {
+				return errors.Wrapf(err, "error checking if container path exists on host")
+			}
+		}
+
 		path, err := resolveSymbolicLink(device.HostPath, "/")
 		if err != nil {
 			return err

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -35,7 +35,7 @@
 	"devices": [
 		{
 			"host_path": "/dev/null",
-			"container_path": "/dev/mynull",
+			"container_path": "%containerdevicepath%",
 			"permissions": "rwm"
 		}
 	],
@@ -59,13 +59,9 @@
 			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
+			"privileged": "%privilegedboolean%",
 			"namespace_options": {
 				"pid": 1
-			},
-			"capabilities": {
-				"add_capabilities": [
-					"sys_admin"
-				]
 			}
 		}
 	}

--- a/test/testdata/sandbox_config_privileged.json
+++ b/test/testdata/sandbox_config_privileged.json
@@ -1,0 +1,50 @@
+{
+	"metadata": {
+		"name": "podsandbox1",
+		"uid": "redhat-test-crio",
+		"namespace": "redhat.test.crio",
+		"attempt": 1
+	},
+	"hostname": "crictl_host",
+	"log_directory": "",
+	"dns_config": {
+		"searches": [
+			"8.8.8.8"
+		]
+	},
+	"port_mappings": [],
+	"resources": {
+		"cpu": {
+			"limits": 3,
+			"requests": 2
+		},
+		"memory": {
+			"limits": 50000000,
+			"requests": 2000000
+		}
+	},
+	"labels": {
+		"group": "test"
+	},
+	"annotations": {
+		"owner": "hmeng",
+		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
+	},
+	"linux": {
+		"cgroup_parent": "/Burstable/pod_123-456",
+		"security_context": {
+			"namespace_options": {
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
+			},
+			"privileged": true,
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "svirt_lxc_net_t",
+				"level": "s0:c4,c5"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Before, device mounting was disabled when a container was privileged, because there was no clear way to make distinctions between mounts on the host and directories in the container. Resolve this by decreeing a privileged container cannot mount a device that already exists on the host. This allows privileged container mounts to work in other cases.

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
