### PR TITLE
[1.12] Allow device mounting to work in privileged mode

### DIFF
--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -674,7 +674,14 @@ function teardown() {
 	echo "$output"
 	[ "$status" -eq 0 ]
 	pod_id="$output"
-	run crictl create "$pod_id" "$TESTDATA"/container_redis_device.json "$TESTDATA"/sandbox_config.json
+
+	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	cp "$TESTDATA"/container_redis_device.json "$newconfig"
+	sed -i 's|"%containerdevicepath%"|"/dev/mynull"|' "$newconfig"
+
+	sed -i 's|"%privilegedboolean%"|false|' "$newconfig"
+
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config.json
 	echo "$output"
 	[ "$status" -eq 0 ]
 	ctr_id="$output"
@@ -691,6 +698,70 @@ function teardown() {
 	run crictl rmp "$pod_id"
 	echo "$output"
 	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "privileged ctr device add" {
+	# In an user namespace we can only bind mount devices from the host, not mknod
+	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+	if test -n "$UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	start_crio
+	run crictl runp "$TESTDATA"/sandbox_config_privileged.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	cp "$TESTDATA"/container_redis_device.json "$newconfig"
+	sed -i 's|"%containerdevicepath%"|"/dev/mynull"|' "$newconfig"
+	sed -i 's|"%privilegedboolean%"|true|' "$newconfig"
+
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config_privileged.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl exec --sync "$ctr_id" ls /dev/mynull
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "/dev/mynull" ]]
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "privileged ctr add duplicate device as host" {
+	# In an user namespace we can only bind mount devices from the host, not mknod
+	# https://github.com/opencontainers/runc/blob/master/libcontainer/rootfs_linux.go#L480-L481
+	if test -n "$UID_MAPPINGS"; then
+		skip "userNS enabled"
+	fi
+	start_crio
+	run crictl runp "$TESTDATA"/sandbox_config_privileged.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	newconfig=$(mktemp --tmpdir crio-config.XXXXXX.json)
+	cp "$TESTDATA"/container_redis_device.json "$newconfig"
+	sed -i 's|"%containerdevicepath%"|"/dev/random"|' "$newconfig"
+	sed -i 's|"%privilegedboolean%"|true|' "$newconfig"
+
+	run crictl create "$pod_id" "$newconfig" "$TESTDATA"/sandbox_config_privileged.json
+	echo "$output"
+	[ "$status" -ne 0 ]
 	cleanup_ctrs
 	cleanup_pods
 	stop_crio

--- a/test/testdata/container_redis_device.json
+++ b/test/testdata/container_redis_device.json
@@ -35,7 +35,7 @@
 	"devices": [
 		{
 			"host_path": "/dev/null",
-			"container_path": "/dev/mynull",
+			"container_path": "%containerdevicepath%",
 			"permissions": "rwm"
 		}
 	],
@@ -59,13 +59,9 @@
 			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
+			"privileged": "%privilegedboolean%",
 			"namespace_options": {
 				"pid": 1
-			},
-			"capabilities": {
-				"add_capabilities": [
-					"sys_admin"
-				]
 			}
 		}
 	}

--- a/test/testdata/sandbox_config_privileged.json
+++ b/test/testdata/sandbox_config_privileged.json
@@ -1,0 +1,50 @@
+{
+	"metadata": {
+		"name": "podsandbox1",
+		"uid": "redhat-test-crio",
+		"namespace": "redhat.test.crio",
+		"attempt": 1
+	},
+	"hostname": "crictl_host",
+	"log_directory": "",
+	"dns_config": {
+		"searches": [
+			"8.8.8.8"
+		]
+	},
+	"port_mappings": [],
+	"resources": {
+		"cpu": {
+			"limits": 3,
+			"requests": 2
+		},
+		"memory": {
+			"limits": 50000000,
+			"requests": 2000000
+		}
+	},
+	"labels": {
+		"group": "test"
+	},
+	"annotations": {
+		"owner": "hmeng",
+		"security.alpha.kubernetes.io/seccomp/pod": "unconfined"
+	},
+	"linux": {
+		"cgroup_parent": "/Burstable/pod_123-456",
+		"security_context": {
+			"namespace_options": {
+				"network": 0,
+				"pid": 1,
+				"ipc": 0
+			},
+			"privileged": true,
+			"selinux_options": {
+				"user": "system_u",
+				"role": "system_r",
+				"type": "svirt_lxc_net_t",
+				"level": "s0:c4,c5"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Before, device mounting was disabled when a container was privileged, because there was no clear way to make distinctions between mounts on the host and directories in the container. Resolve this by decreeing a privileged container cannot mount a device that already exists on the host. This allows privileged container mounts to work in other cases.

Signed-off-by: Peter Hunt <pehunt@redhat.com>