### PR TITLE
Remove camel-case imageName runtime test

### DIFF
--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -31,7 +31,8 @@ var _ = t.Describe("Runtime", func() {
 	mockToCreate := func() {
 		gomock.InOrder(
 			imageServerMock.EXPECT().GetStore().Return(storeMock),
-			storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
+			storeMock.EXPECT().Image(gomock.Any()).
+				Return(nil, cstorage.ErrImageUnknown),
 			storeMock.EXPECT().GraphOptions().Return([]string{}),
 			storeMock.EXPECT().GraphDriverName().Return(""),
 			storeMock.EXPECT().GraphRoot().Return(""),
@@ -589,77 +590,6 @@ var _ = t.Describe("Runtime", func() {
 				// When
 				info, err = sut.CreatePodSandbox(&types.SystemContext{},
 					"podName", "podID", "imagename",
-					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
-					"containerName", "metadataName",
-					"uid", "namespace", 0, &idtools.IDMappings{})
-
-			})
-
-			AfterEach(func() {
-				// Then
-				Expect(err).To(BeNil())
-				Expect(info).NotTo(BeNil())
-				Expect(info.ID).To(Equal("id"))
-				Expect(info.Dir).To(Equal("dir"))
-				Expect(info.RunDir).To(Equal("runDir"))
-			})
-		})
-
-		t.Describe("success invalid (camel-case) image name", func() {
-			var (
-				info storage.ContainerInfo
-				err  error
-			)
-
-			BeforeEach(func() {
-				// Given
-				gomock.InOrder(
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().GraphOptions().Return([]string{}),
-					storeMock.EXPECT().GraphDriverName().Return(""),
-					storeMock.EXPECT().GraphRoot().Return(""),
-					storeMock.EXPECT().RunRoot().Return(""),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
-					storeMock.EXPECT().Image(gomock.Any()).Return(&cs.Image{}, nil),
-					storeMock.EXPECT().ImageBigData(gomock.Any(), gomock.Any()).
-						Return(testManifest, nil),
-					storeMock.EXPECT().ListImageBigData(gomock.Any()).
-						Return([]string{""}, nil),
-					storeMock.EXPECT().ImageBigDataSize(gomock.Any(), gomock.Any()).
-						Return(int64(0), nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().CreateContainer(gomock.Any(), gomock.Any(),
-						gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-						Return(&cs.Container{ID: "id"}, nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().Names(gomock.Any()).Return([]string{}, nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().SetNames(gomock.Any(), gomock.Any()).Return(nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().ContainerDirectory(gomock.Any()).
-						Return("dir", nil),
-					imageServerMock.EXPECT().GetStore().Return(storeMock),
-					storeMock.EXPECT().ContainerRunDirectory(gomock.Any()).
-						Return("runDir", nil),
-				)
-			})
-
-			It("should succeed to create a container", func() {
-				// When
-				info, err = sut.CreateContainer(&types.SystemContext{},
-					"podName", "podID", "imageName",
-					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
-					"containerName", "containerID", "",
-					0, "mountLabel", &idtools.IDMappings{})
-			})
-
-			It("should succeed to create a pod sandbox", func() {
-				// When
-				info, err = sut.CreatePodSandbox(&types.SystemContext{},
-					"podName", "podID", "imageName",
 					"8a788232037eaf17794408ff3df6b922a1aedf9ef8de36afdae3ed0b0381907b",
 					"containerName", "metadataName",
 					"uid", "namespace", 0, &idtools.IDMappings{})


### PR DESCRIPTION
As a follow up of #2132 we decided to remove the camel-case test because it does not match any real world scenario. Beside this, a small return value by the mock is fixed.

This PR should decrease the unit test coverage a bit.