### PR TITLE
[1.9] runPodSandbox: clean up containers on error path

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -13,10 +13,6 @@
   args:
     chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
 
-- name: build kubernetes
-  make:
-    chdir: "{{ ansible_env.GOPATH }}/src/k8s.io/kubernetes"
-
 - name: Add custom cluster service file for the e2e testing
   copy:
     dest: /etc/systemd/system/customcluster.service

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -70,7 +70,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.9.2"
+          version: "1.11.6"
     - name: setup critest
       include: "build/cri-tools.yml"
       vars:

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -83,7 +83,7 @@
       vars:
           force_clone: True
           k8s_git_version: "release-1.9"
-          k8s_github_fork: "kubernetes"
+          k8s_github_fork: "mrunalp"
           crio_socket: "/var/run/crio/crio.sock"
     - name: run k8s e2e tests
       include: e2e.yml

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -161,7 +161,7 @@ type Sandbox struct {
 	hostname       string
 	portMappings   []*hostport.PortMapping
 	stopped        bool
-	stopMutex      sync.Mutex
+	stopMutex      sync.RWMutex
 	// ipv4 or ipv6 cache
 	ip                 string
 	seccompProfilePath string
@@ -232,7 +232,7 @@ func (s *Sandbox) AddIP(ip string) {
 }
 
 // StopMutex returns the mutex to use when stopping the sandbox
-func (s *Sandbox) StopMutex() *sync.Mutex {
+func (s *Sandbox) StopMutex() *sync.RWMutex {
 	return &s.stopMutex
 }
 

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -161,6 +161,7 @@ type Sandbox struct {
 	hostname       string
 	portMappings   []*hostport.PortMapping
 	stopped        bool
+	stopMutex      sync.Mutex
 	// ipv4 or ipv6 cache
 	ip                 string
 	seccompProfilePath string
@@ -228,6 +229,11 @@ func (s *Sandbox) SeccompProfilePath() string {
 // AddIP stores the ip in the sandbox
 func (s *Sandbox) AddIP(ip string) {
 	s.ip = ip
+}
+
+// StopMutex returns the mutex to use when stopping the sandbox
+func (s *Sandbox) StopMutex() *sync.Mutex {
+	return &s.stopMutex
 }
 
 // IP returns the ip of the sandbox

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -556,6 +556,12 @@ func (s *Server) CreateContainer(ctx context.Context, req *pb.CreateContainerReq
 	if sb == nil {
 		return nil, fmt.Errorf("specified sandbox not found: %s", sandboxID)
 	}
+	stopMutex := sb.StopMutex()
+	stopMutex.RLock()
+	defer stopMutex.RUnlock()
+	if sb.Stopped() {
+		return nil, fmt.Errorf("CreateContainer failed as the sandbox was stopped: %v", sbID)
+	}
 
 	// The config of the container
 	containerConfig := req.GetConfig()

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -544,6 +544,20 @@ func (s *Server) RunPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
+	defer func() {
+		if err != nil {
+			// Clean-up steps from RemovePodSanbox
+			timeout := int64(10)
+			if err2 := s.Runtime().StopContainer(ctx, container, timeout); err2 != nil {
+				logrus.Warnf("failed to stop container %s: %v", container.Name(), err2)
+			}
+			if err2 := s.Runtime().DeleteContainer(container); err2 != nil {
+				logrus.Warnf("failed to delete container %s in pod sandbox %s: %v", container.Name(), sb.ID(), err2)
+			}
+			s.ContainerStateToDisk(container)
+		}
+	}()
+
 	s.ContainerStateToDisk(container)
 
 	if !s.config.Config.ManageNetworkNSLifecycle {

--- a/server/sandbox_stop.go
+++ b/server/sandbox_stop.go
@@ -42,6 +42,9 @@ func (s *Server) StopPodSandbox(ctx context.Context, req *pb.StopPodSandboxReque
 		logrus.Debugf("StopPodSandboxResponse %s: %+v", req.PodSandboxId, resp)
 		return resp, nil
 	}
+	stopMutex := sb.StopMutex()
+	stopMutex.Lock()
+	defer stopMutex.Unlock()
 
 	if sb.Stopped() {
 		resp = &pb.StopPodSandboxResponse{}


### PR DESCRIPTION
Closes #1973 

If the CNI setup fails in runPodSandbox, the infra container started is
not stopped/removed and leaks.

Ensure the necessary clean-up steps are executed on error
path.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>
Signed-off-by: Antonio Murdaca <runcom@linux.com>

