### PR TITLE
Update linter to use gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - dupl
     - gochecknoinits
     - goconst
+    - gocritic
     - gofmt
     - ineffassign
     - interfacer
@@ -19,7 +20,6 @@ linters:
     - varcheck
     # - errcheck
     # - gochecknoglobals
-    # - gocritic
     # - gocyclo
     # - goimports
     # - golint
@@ -36,3 +36,74 @@ linters:
 issues:
   exclude:
     - .*_Ctype_security_context_t.*
+linters-settings:
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - weakCond
+      # - appendAssign
+      # - octalLiteral
+      # - sloppyReassign
+
+      # Performance
+      - equalFold
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+      # - appendCombine
+      # - hugeParam
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - ifElseChain
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - yodaStyleExpr
+      # - wrapperFunc
+
+      # Opinionated
+      - initClause
+      - nestingReduce
+      - ptrToRefParam
+      - typeUnparen
+      - unnecessaryBlock
+      # - builtinShadow
+      # - importShadow
+      # - paramTypeCombine
+      # - unnamedResult

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -531,7 +531,8 @@ func main() {
 
 		args := c.Args()
 		if len(args) > 0 {
-			for _, command := range app.Commands {
+			for i := range app.Commands {
+				command := &app.Commands[i]
 				if args[0] == command.Name {
 					break
 				}

--- a/lib/config.go
+++ b/lib/config.go
@@ -141,7 +141,7 @@ type RuntimeConfig struct {
 	// will also be used for untrusted container workloads if
 	// RuntimeUntrustedWorkload is not set.
 	//
-	// DEPRECATED: use Runtimes instead.
+	// Deprecated: use Runtimes instead.
 	//
 	Runtime string `toml:"runtime"`
 
@@ -152,7 +152,7 @@ type RuntimeConfig struct {
 	// RuntimeUntrustedWorkload is the OCI compatible runtime used for
 	// untrusted container workloads. This is an optional setting, except
 	// if DefaultWorkloadTrust is set to "untrusted".
-	// DEPRECATED: use Runtimes instead. If provided, this runtime is
+	// Deprecated: use Runtimes instead. If provided, this runtime is
 	//     mapped to the runtime handler named 'untrusted'. It is a
 	//     configuration error to provide both the (now deprecated)
 	//     RuntimeUntrustedWorkload and a handler in the Runtimes handler
@@ -177,7 +177,7 @@ type RuntimeConfig struct {
 	// containers are by definition trusted and will always use the trusted container
 	// runtime. If DefaultWorkloadTrust is set to "trusted", crio will use the trusted
 	// container runtime for all containers.
-	// DEPRECATED: The runtime handler should provide a key to the map of runtimes,
+	// Deprecated: The runtime handler should provide a key to the map of runtimes,
 	//     avoiding the need to rely on the level of trust of the workload to choose
 	//     an appropriate runtime.
 	//     The support of this option will continue through versions 1.12 and 1.13.

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -235,7 +235,8 @@ func (c *ContainerServer) Update() error {
 	newPodContainers := map[string]*storage.RuntimeContainerMetadata{}
 	oldPodContainers := map[string]string{}
 	removedPodContainers := map[string]string{}
-	for _, container := range containers {
+	for i := range containers {
+		container := &containers[i]
 		if c.HasSandbox(container.ID) {
 			// FIXME: do we need to reload/update any info about the sandbox?
 			oldPods[container.ID] = container.ID

--- a/lib/rename.go
+++ b/lib/rename.go
@@ -86,7 +86,8 @@ func (c *ContainerServer) updateStateName(ctr *oci.Container, name string) error
 func updateMetadata(specAnnotations map[string]string, name string) string {
 	oldMetadata := specAnnotations[annotations.Metadata]
 	containerType := specAnnotations[annotations.ContainerType]
-	if containerType == "container" {
+	switch containerType {
+	case "container":
 		metadata := runtime.ContainerMetadata{}
 		err := json.Unmarshal([]byte(oldMetadata), &metadata)
 		if err != nil {
@@ -98,7 +99,8 @@ func updateMetadata(specAnnotations map[string]string, name string) string {
 			return oldMetadata
 		}
 		return string(m)
-	} else if containerType == "sandbox" {
+
+	case "sandbox":
 		metadata := runtime.PodSandboxMetadata{}
 		err := json.Unmarshal([]byte(oldMetadata), &metadata)
 		if err != nil {
@@ -110,7 +112,8 @@ func updateMetadata(specAnnotations map[string]string, name string) string {
 			return oldMetadata
 		}
 		return string(m)
-	} else {
+
+	default:
 		return specAnnotations[annotations.Metadata]
 	}
 }

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -58,10 +58,8 @@ func (s *Sandbox) NetNsGet(nspath, name string) (*NetNs, error) {
 		}
 
 		netNs.symlink = fd
-	} else {
-		if err := netNs.SymlinkCreate(name); err != nil {
-			return nil, err
-		}
+	} else if err := netNs.SymlinkCreate(name); err != nil {
+		return nil, err
 	}
 
 	return netNs, nil

--- a/oci/attach.go
+++ b/oci/attach.go
@@ -21,14 +21,14 @@ func redirectResponseToOutputStreams(outputStream, errorStream io.WriteCloser, c
 		nr, er := conn.Read(buf)
 		if nr > 0 {
 			var dst io.Writer
-			if buf[0] == AttachPipeStdout {
+			switch buf[0] {
+			case AttachPipeStdout:
 				dst = outputStream
-			} else if buf[0] == AttachPipeStderr {
+			case AttachPipeStderr:
 				dst = errorStream
-			} else {
+			default:
 				logrus.Debugf("Got unexpected attach type %+d", buf[0])
 			}
-
 			if dst != nil {
 				nw, ew := dst.Write(buf[1:nr])
 				if ew != nil {

--- a/pkg/storage/image.go
+++ b/pkg/storage/image.go
@@ -263,12 +263,13 @@ func (svc *imageService) ListImages(systemContext *types.SystemContext, filter s
 			return nil, err
 		}
 		newImageCache := make(imageCache, len(images))
-		for _, image := range images {
+		for i := range images {
+			image := &images[i]
 			ref, err := istorage.Transport.ParseStoreReference(svc.store, "@"+image.ID)
 			if err != nil {
 				return nil, err
 			}
-			results, err = svc.appendCachedResult(systemContext, ref, &image, results, newImageCache)
+			results, err = svc.appendCachedResult(systemContext, ref, image, results, newImageCache)
 			if err != nil {
 				return nil, err
 			}

--- a/server/config_unix.go
+++ b/server/config_unix.go
@@ -2,7 +2,7 @@
 
 package server
 
-//CrioConfigPath is the default location for the conf file
+// CrioConfigPath is the default location for the conf file
 const CrioConfigPath = "/etc/crio/crio.conf"
 
 // CrioSocketPath is where the unix socket is located

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -219,12 +219,12 @@ func addDevices(sb *sandbox.Sandbox, containerConfig *pb.ContainerConfig, specge
 
 // buildOCIProcessArgs build an OCI compatible process arguments slice.
 func buildOCIProcessArgs(containerKubeConfig *pb.ContainerConfig, imageOCIConfig *v1.Image) ([]string, error) {
-	//# Start the nginx container using the default command, but use custom
-	//arguments (arg1 .. argN) for that command.
-	//kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
+	// # Start the nginx container using the default command, but use custom
+	// arguments (arg1 .. argN) for that command.
+	// kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
 
-	//# Start the nginx container using a different command and custom arguments.
-	//kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
+	// # Start the nginx container using a different command and custom arguments.
+	// kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
 
 	kubeCommands := containerKubeConfig.Command
 	kubeArgs := containerKubeConfig.Args
@@ -405,7 +405,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 	}
 
 	for _, cap := range capabilities.GetAddCapabilities() {
-		if strings.ToUpper(cap) == "ALL" {
+		if strings.EqualFold(cap, "ALL") {
 			continue
 		}
 		capPrefixed := toCAPPrefixed(cap)
@@ -428,7 +428,7 @@ func setupCapabilities(specgen *generate.Generator, capabilities *pb.Capability)
 	}
 
 	for _, cap := range capabilities.GetDropCapabilities() {
-		if strings.ToUpper(cap) == "ALL" {
+		if strings.EqualFold(cap, "ALL") {
 			continue
 		}
 		capPrefixed := toCAPPrefixed(cap)

--- a/server/container_list.go
+++ b/server/container_list.go
@@ -51,14 +51,12 @@ func (s *Server) filterContainerList(filter *pb.ContainerFilter, origCtrList []*
 				return []*oci.Container{}
 			}
 		}
-	} else {
-		if filter.PodSandboxId != "" {
-			pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
-			if pod == nil {
-				return []*oci.Container{}
-			}
-			return pod.Containers().List()
+	} else if filter.PodSandboxId != "" {
+		pod := s.ContainerServer.GetSandbox(filter.PodSandboxId)
+		if pod == nil {
+			return []*oci.Container{}
 		}
+		return pod.Containers().List()
 	}
 	logrus.Debug("no filters were applied, returning full container list")
 	return origCtrList

--- a/server/image_list.go
+++ b/server/image_list.go
@@ -30,7 +30,8 @@ func (s *Server) ListImages(ctx context.Context, req *pb.ListImagesRequest) (res
 		return nil, err
 	}
 	resp = &pb.ListImagesResponse{}
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		resImg := &pb.Image{
 			Id:          result.ID,
 			RepoTags:    result.RepoTags,

--- a/server/server.go
+++ b/server/server.go
@@ -154,7 +154,8 @@ func (s *Server) restore() {
 	pods := map[string]*storage.RuntimeContainerMetadata{}
 	podContainers := map[string]*storage.RuntimeContainerMetadata{}
 	names := map[string][]string{}
-	for _, container := range containers {
+	for i := range containers {
+		container := &containers[i]
 		metadata, err2 := s.StorageRuntimeServer().GetContainerMetadata(container.ID)
 		if err2 != nil {
 			logrus.Warnf("error parsing metadata for %s: %v, ignoring", container.ID, err2)

--- a/server/utils.go
+++ b/server/utils.go
@@ -112,7 +112,7 @@ func newPodNetwork(sb *sandbox.Sandbox) ocicni.PodNetwork {
 // Comparison is case insensitive.
 func inStringSlice(ss []string, str string) bool {
 	for _, s := range ss {
-		if strings.ToLower(s) == strings.ToLower(str) {
+		if strings.EqualFold(s, str) {
 			return true
 		}
 	}

--- a/test/copyimg/copyimg.go
+++ b/test/copyimg/copyimg.go
@@ -187,13 +187,11 @@ func main() {
 					os.Exit(1)
 				}
 			}
-		} else {
-			if importFrom != "" && exportTo != "" {
-				_, err = copy.Image(ctx, policyContext, exportRef, importRef, options)
-				if err != nil {
-					logrus.Errorf("error copying %s to %s: %v", importFrom, exportTo, err)
-					os.Exit(1)
-				}
+		} else if importFrom != "" && exportTo != "" {
+			_, err = copy.Image(ctx, policyContext, exportRef, importRef, options)
+			if err != nil {
+				logrus.Errorf("error copying %s to %s: %v", importFrom, exportTo, err)
+				os.Exit(1)
 			}
 		}
 		return nil

--- a/utils/filesystem.go
+++ b/utils/filesystem.go
@@ -7,10 +7,8 @@ import (
 
 // GetDiskUsageStats accepts a path to a directory or file
 // and returns the number of bytes and inodes used by the path
-func GetDiskUsageStats(path string) (uint64, uint64, error) {
-	var dirSize, inodeCount uint64
-
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+func GetDiskUsageStats(path string) (dirSize, inodeCount uint64, err error) {
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		// Walk does not follow symbolic links
 		if err != nil {
 			return err


### PR DESCRIPTION
I enabled [go-critic](https://github.com/go-critic/go-critic) within the golangci-lint configuration. Beside this, I enabled all go-critic internal linters which made sense to me and caused no larger fixes.

Some fixes are just style related, but others avoid unnecessary copying of structures which could have a real performance impact, like this:

```go
for i := range containers {
	container := &containers[i]
}
```