### PR TITLE
[1.10] test: Switch to golang 1.11.6

### DIFF
--- a/contrib/test/integration/e2e.yml
+++ b/contrib/test/integration/e2e.yml
@@ -58,7 +58,7 @@
         /usr/bin/go run hack/e2e.go
             --test
             --test_args="-host=https://{{ ansible_default_ipv4.address }}:6443
-                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host
+                        --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PersistentVolumes|\[HPA\]|should.support.building.a.client.with.a.CSR|should.support.inline.execution.and.attach|should.propagate.mounts.to.the.host|Proxy.version.v1.should.proxy.to.cadvisor.using.proxy.subresource
                         --report-dir={{ artifacts }}"
             &> {{ artifacts }}/e2e.log
   # Fix vim syntax hilighting: "

--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -73,7 +73,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.9.2"
+          version: "1.11.6"
     - name: setup critest
       include: "build/cri-tools.yml"
       vars:
@@ -92,7 +92,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.9.2"
+          version: "1.11.6"
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:
@@ -113,7 +113,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.9.2"
+          version: "1.11.6"
     - name: clone build and install kubernetes
       include: "build/kubernetes.yml"
       vars:


### PR DESCRIPTION
Some of the packages that we rely on don't compile with 1.9 anymore.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

