### PR TITLE
config: Remove trusted/untrusted support for 1.14

### DIFF
--- a/cmd/crio/config.go
+++ b/cmd/crio/config.go
@@ -92,55 +92,9 @@ grpc_max_recv_msg_size = {{ .GRPCMaxRecvMsgSize }}
 #default_ulimits = [
 {{ range $ulimit := .DefaultUlimits }}{{ printf "#\t%q,\n" $ulimit }}{{ end }}#]
 
-# Path to the OCI compatible runtime used for trusted container workloads. This
-# is a mandatory setting as this runtime will be the default and will also be
-# used for untrusted container workloads if runtime_untrusted_workload is not
-# set.
-#
-# DEPRECATED: use Runtimes instead.
-#
-# runtime = "{{ .Runtime }}"
-
 # default_runtime is the _name_ of the OCI runtime to be used as the default.
 # The name is matched against the runtimes map below.
 default_runtime = "{{ .DefaultRuntime }}"
-
-# Path to OCI compatible runtime used for untrusted container workloads. This
-# is an optional setting, except if default_container_trust is set to
-# "untrusted".
-# DEPRECATED: use "crio.runtime.runtimes" instead. If provided, this
-#     runtime is mapped to the runtime handler named 'untrusted'. It is
-#     a configuration error to provide both the (now deprecated)
-#     runtime_untrusted_workload and a handler in the Runtimes handler
-#     map (below) for 'untrusted' workloads at the same time. Please
-#     provide one or the other.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#runtime_untrusted_workload = "{{ .RuntimeUntrustedWorkload }}"
-
-# Default level of trust CRI-O puts in container workloads. It can either be
-# "trusted" or "untrusted", and the default is "trusted". Containers can be run
-# through different container runtimes, depending on the trust hints we receive
-# from kubelet:
-#
-#   - If kubelet tags a container workload as untrusted, CRI-O will try first
-#     to run it through the untrusted container workload runtime. If it is not
-#     set, CRI-O will use the trusted runtime.
-#
-#   - If kubelet does not provide any information about the container workload
-#     trust level, the selected runtime will depend on the default_container_trust
-#     setting. If it is set to untrusted, then all containers except for the host
-#     privileged ones, will be run by the runtime_untrusted_workload runtime. Host
-#     privileged containers are by definition trusted and will always use the
-#     trusted container runtime. If default_container_trust is set to "trusted",
-#     CRI-O will use the trusted container runtime for all containers.
-#
-# DEPRECATED: The runtime handler should provide a key to the map of runtimes,
-#     avoiding the need to rely on the level of trust of the workload to choose
-#     an appropriate runtime.
-#     The support of this option will continue through versions 1.12 and 1.13.
-#     By version 1.14, this option will no longer exist.
-#default_workload_trust = "{{ .DefaultWorkloadTrust }}"
 
 # If true, the runtime will not use pivot_root, but instead use MS_MOVE.
 no_pivot = {{ .NoPivot }}

--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -114,10 +114,6 @@ func mergeConfig(config *server.Config, ctx *cli.Context) error {
 	if ctx.GlobalIsSet("stream-port") {
 		config.StreamPort = ctx.GlobalString("stream-port")
 	}
-	if ctx.GlobalIsSet("runtime") {
-		logrus.Warn("--runtime is deprecated, use the runtimes key in the config directly")
-		config.Runtime = ctx.GlobalString("runtime")
-	}
 	if ctx.GlobalIsSet("default-runtime") {
 		config.DefaultRuntime = ctx.GlobalString("default-runtime")
 	}

--- a/docs/crio.conf.5.md
+++ b/docs/crio.conf.5.md
@@ -75,23 +75,6 @@ The `crio.api` table contains settings for the kubelet/gRPC interface.
 ## CRIO.RUNTIME TABLE
 The `crio.runtime` table contains settings pertaining to the OCI runtime used and options for how to set up and manage the OCI runtime.
 
-**runtime**="/usr/bin/runc"
-  Path to the OCI compatible runtime used for trusted container workloads. This is a mandatory setting as this runtime will be the default and will also be used for untrusted container workloads if `runtime_untrusted_workload` is not set.
-
-**runtime_untrusted_workload**=""
-   **Deprecated:** use "crio.runtime.runtimes" instead. If provided, this runtime is mapped to the runtime handler named 'untrusted'. It is a configuration error to provide both the (now deprecated) runtime_untrusted_workload and a handler in the Runtimes handler map (below) for 'untrusted' workloads at the same time. Please provide one or the other.  The support of this option will continue through versions 1.12 and 1.13.  By version 1.14, this option will no longer exist.
-
-   Path to OCI compatible runtime used for untrusted container workloads. This is an optional setting, except if `default_container_trust` is set to "untrusted".
-
-**default_workload_trust**="trusted"
-  **Deprecated:** The runtime handler should provide a key to the map of runtimes, avoiding the need to rely on the level of trust of the workload to choose an appropriate runtime.  The support of this option will continue through versions 1.12 and 1.13.  By version 1.14, this option will no longer exist.
-
-  Default level of trust CRI-O puts in container workloads. It can either be "trusted" or "untrusted", and the default is "trusted". Containers can be run through different container runtimes, depending on the trust hints we receive from kubelet:
-
-    - If kubelet tags a container workload as untrusted, CRI-O will try first to run it through the untrusted container workload runtime. If it is not set, CRI-O will use the trusted runtime.
-
-    - If kubelet does not provide any information about the container workload trust level, the selected runtime will depend on the default_container_trust setting. If it is set to untrusted, then all containers except for the host privileged ones, will be run by the runtime_untrusted_workload runtime. Host privileged containers are by definition trusted and will always use the trusted container runtime. If default_container_trust is set to "trusted", CRI-O will use the trusted container runtime for all containers.
-
 **no_pivot**=*false*
   If true, the runtime will not use `pivot_root`, but instead use `MS_MOVE`.
 

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -44,7 +44,6 @@ var _ = t.Describe("Config", func() {
 		It("should succeed with additional devices", func() {
 			// Given
 			sut.AdditionalDevices = []string{"/dev/null:/dev/null:rw"}
-			sut.DefaultWorkloadTrust = "DefaultWorkloadTrust"
 			sut.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: "/bin/sh"}
 
 			// When
@@ -126,29 +125,6 @@ var _ = t.Describe("Config", func() {
 
 			// When
 			err := sut.Validate(false)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail on conflicting definitions", func() {
-			// Given
-			sut.Runtimes[oci.UntrustedRuntime] = oci.RuntimeHandler{}
-			sut.RuntimeUntrustedWorkload = "value"
-
-			// When
-			err := sut.Validate(false)
-
-			// Then
-			Expect(err).NotTo(BeNil())
-		})
-
-		It("should fail on non existing runtime", func() {
-			// Given
-			sut.Runtime = "not-existing"
-
-			// When
-			err := sut.Validate(true)
 
 			// Then
 			Expect(err).NotTo(BeNil())

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -140,7 +140,7 @@ func New(ctx context.Context, configIface ConfigIface) (*ContainerServer, error)
 
 	storageRuntimeService := storage.GetRuntimeService(ctx, imageService, config.PauseImage, config.PauseImageAuthFile)
 
-	runtime, err := oci.New(config.Runtime, config.RuntimeUntrustedWorkload, config.DefaultWorkloadTrust, config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout, "v1")
+	runtime, err := oci.New(config.DefaultRuntime, config.Runtimes, config.Conmon, config.ConmonEnv, config.CgroupManager, config.ContainerExitsDir, config.ContainerAttachSocketDir, config.LogSizeMax, config.LogToJournald, config.NoPivot, config.CtrStopTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -379,14 +379,13 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	}
 
 	privileged := isTrue(m.Annotations[annotations.PrivilegedRuntime])
-	trusted := isTrue(m.Annotations[annotations.TrustedSandbox])
 	hostNetwork := isTrue(m.Annotations[annotations.HostNetwork])
 	nsOpts := pb.NamespaceOption{}
 	if err := json.Unmarshal([]byte(m.Annotations[annotations.NamespaceOptions]), &nsOpts); err != nil {
 		return err
 	}
 
-	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, trusted, m.Annotations[annotations.RuntimeHandler], m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork)
+	sb, err := sandbox.New(id, m.Annotations[annotations.Namespace], name, m.Annotations[annotations.KubeName], filepath.Dir(m.Annotations[annotations.LogPath]), labels, kubeAnnotations, processLabel, mountLabel, &metadata, m.Annotations[annotations.ShmPath], m.Annotations[annotations.CgroupParent], privileged, m.Annotations[annotations.RuntimeHandler], m.Annotations[annotations.ResolvPath], m.Annotations[annotations.HostName], portMappings, hostNetwork)
 	if err != nil {
 		return err
 	}
@@ -442,7 +441,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 		return err
 	}
 
-	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, trusted, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	scontainer, err := oci.NewContainer(m.Annotations[annotations.ContainerID], cname, sandboxPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, privileged, sb.RuntimeHandler(), sandboxDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}
@@ -565,7 +564,7 @@ func (c *ContainerServer) LoadContainer(id string) error {
 		return err
 	}
 
-	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.Trusted(), sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
+	ctr, err := oci.NewContainer(id, name, containerPath, m.Annotations[annotations.LogPath], sb.NetNs().Path(), labels, m.Annotations, kubeAnnotations, img, imgName, imgRef, &metadata, sb.ID(), tty, stdin, stdinOnce, sb.Privileged(), sb.RuntimeHandler(), containerDir, created, m.Annotations["org.opencontainers.image.stopSignal"])
 	if err != nil {
 		return err
 	}

--- a/lib/container_server_test.go
+++ b/lib/container_server_test.go
@@ -79,7 +79,6 @@ var _ = t.Describe("ContainerServer", func() {
 		It("should fail with invalid default runtime", func() {
 			// Given
 			config := lib.DefaultConfig()
-			config.Runtime = ""
 			config.DefaultRuntime = "invalid-runtime"
 			gomock.InOrder(
 				libMock.EXPECT().GetStore().Return(storeMock, nil),
@@ -836,7 +835,7 @@ var _ = t.Describe("ContainerServer", func() {
 			container, err := oci.NewContainer(containerID, "", "", "", "",
 				make(map[string]string), make(map[string]string),
 				make(map[string]string), "", "", "",
-				&pb.ContainerMetadata{}, sandboxID, false, false, false,
+				&pb.ContainerMetadata{}, sandboxID, false, false,
 				false, false, "", "/invalid", time.Now(), "")
 			Expect(err).To(BeNil())
 

--- a/lib/sandbox/history_test.go
+++ b/lib/sandbox/history_test.go
@@ -17,7 +17,7 @@ var _ = t.Describe("History", func() {
 		beforeEach()
 		otherTestSandbox, err := sandbox.New("sandboxID", "", "", "", "",
 			make(map[string]string), make(map[string]string), "", "",
-			&pb.PodSandboxMetadata{}, "", "", false, false, "", "", "",
+			&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
 			[]*hostport.PortMapping{}, false)
 		Expect(err).To(BeNil())
 		Expect(testSandbox).NotTo(BeNil())

--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -91,7 +91,6 @@ type Sandbox struct {
 	shmPath        string
 	cgroupParent   string
 	privileged     bool
-	trusted        bool
 	runtimeHandler string
 	resolvPath     string
 	hostnamePath   string
@@ -150,7 +149,7 @@ var (
 // New creates and populates a new pod sandbox
 // New sandboxes have no containers, no infra container, and no network namespaces associated with them
 // An infra container must be attached before the sandbox is added to the state
-func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged, trusted bool, runtimeHandler string, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool) (*Sandbox, error) {
+func New(id, namespace, name, kubeName, logDir string, labels, annotations map[string]string, processLabel, mountLabel string, metadata *pb.PodSandboxMetadata, shmPath, cgroupParent string, privileged bool, runtimeHandler string, resolvPath, hostname string, portMappings []*hostport.PortMapping, hostNetwork bool) (*Sandbox, error) {
 	sb := new(Sandbox)
 	sb.id = id
 	sb.namespace = namespace
@@ -166,7 +165,6 @@ func New(id, namespace, name, kubeName, logDir string, labels, annotations map[s
 	sb.shmPath = shmPath
 	sb.cgroupParent = cgroupParent
 	sb.privileged = privileged
-	sb.trusted = trusted
 	sb.runtimeHandler = runtimeHandler
 	sb.resolvPath = resolvPath
 	sb.hostname = hostname
@@ -287,11 +285,6 @@ func (s *Sandbox) CgroupParent() string {
 // privileged containers
 func (s *Sandbox) Privileged() bool {
 	return s.privileged
-}
-
-// Trusted returns whether or not the containers in the sandbox are trusted
-func (s *Sandbox) Trusted() bool {
-	return s.trusted
 }
 
 // RuntimeHandler returns the name of the runtime handler that should be

--- a/lib/sandbox/sandbox_test.go
+++ b/lib/sandbox/sandbox_test.go
@@ -34,7 +34,6 @@ var _ = t.Describe("Sandbox", func() {
 			shmPath := "shmPath"
 			cgroupParent := "cgroupParent"
 			privileged := true
-			trusted := false
 			runtimeHandler := "runtimeHandler"
 			resolvPath := "resolvPath"
 			hostname := "hostname"
@@ -44,7 +43,7 @@ var _ = t.Describe("Sandbox", func() {
 			// When
 			sandbox, err := sandbox.New(id, namespace, name, kubeName, logDir,
 				labels, annotations, processLabel, mountLabel, &metadata,
-				shmPath, cgroupParent, privileged, trusted, runtimeHandler,
+				shmPath, cgroupParent, privileged, runtimeHandler,
 				resolvPath, hostname, portMappings, hostNetwork)
 
 			// Then
@@ -63,7 +62,6 @@ var _ = t.Describe("Sandbox", func() {
 			Expect(sandbox.ShmPath()).To(Equal(shmPath))
 			Expect(sandbox.CgroupParent()).To(Equal(cgroupParent))
 			Expect(sandbox.Privileged()).To(Equal(privileged))
-			Expect(sandbox.Trusted()).To(Equal(trusted))
 			Expect(sandbox.RuntimeHandler()).To(Equal(runtimeHandler))
 			Expect(sandbox.ResolvPath()).To(Equal(resolvPath))
 			Expect(sandbox.Hostname()).To(Equal(hostname))
@@ -176,7 +174,7 @@ var _ = t.Describe("Sandbox", func() {
 				"/container/logs", "", map[string]string{},
 				map[string]string{}, map[string]string{}, "image",
 				"imageName", "imageRef", &pb.ContainerMetadata{},
-				"testsandboxid", false, false, false, false, false, "",
+				"testsandboxid", false, false, false, false, "",
 				"/root/for/container", time.Now(), "SIGKILL")
 			testContainer.SetIntermediateMountPoint("/tmp/file")
 			Expect(err).To(BeNil())

--- a/lib/sandbox/suite_test.go
+++ b/lib/sandbox/suite_test.go
@@ -49,7 +49,7 @@ func beforeEach() {
 	var err error
 	testSandbox, err = sandbox.New("sandboxID", "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
-		&pb.PodSandboxMetadata{}, "", "", false, false, "", "", "",
+		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
 		[]*hostport.PortMapping{}, false)
 	Expect(err).To(BeNil())
 	Expect(testSandbox).NotTo(BeNil())

--- a/lib/suite_test.go
+++ b/lib/suite_test.go
@@ -79,7 +79,6 @@ var _ = BeforeSuite(func() {
 			"io.kubernetes.cri-o.SandboxName": "{}",
 			"io.kubernetes.cri-o.ShmPath": "{}",
 			"io.kubernetes.cri-o.MountPoint": "{}",
-			"io.kubernetes.cri-o.TrustedSandbox": "{}",
 			"io.kubernetes.cri-o.Stdin": "{}",
 			"io.kubernetes.cri-o.StdinOnce": "{}",
 			"io.kubernetes.cri-o.Volumes": "[{}]",
@@ -137,14 +136,14 @@ func beforeEach() {
 	// Setup test vars
 	mySandbox, err = sandbox.New(sandboxID, "", "", "", "",
 		make(map[string]string), make(map[string]string), "", "",
-		&pb.PodSandboxMetadata{}, "", "", false, false, "", "", "",
+		&pb.PodSandboxMetadata{}, "", "", false, "", "", "",
 		[]*hostport.PortMapping{}, false)
 	Expect(err).To(BeNil())
 
 	myContainer, err = oci.NewContainer(containerID, "", "", "", "",
 		make(map[string]string), make(map[string]string),
 		make(map[string]string), "", "", "",
-		&pb.ContainerMetadata{}, sandboxID, false, false, false,
+		&pb.ContainerMetadata{}, sandboxID, false, false,
 		false, false, "", "", time.Now(), "")
 	Expect(err).To(BeNil())
 }

--- a/oci/container.go
+++ b/oci/container.go
@@ -38,7 +38,6 @@ type Container struct {
 	stdin           bool
 	stdinOnce       bool
 	privileged      bool
-	trusted         bool
 	runtimeHandler  string
 	created         bool
 	state           *ContainerState
@@ -79,7 +78,7 @@ type ContainerState struct {
 }
 
 // NewContainer creates a container object.
-func NewContainer(id string, name string, bundlePath string, logPath string, netns string, labels map[string]string, crioAnnotations map[string]string, annotations map[string]string, image string, imageName string, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, trusted bool, runtimeHandler string, dir string, created time.Time, stopSignal string) (*Container, error) {
+func NewContainer(id string, name string, bundlePath string, logPath string, netns string, labels map[string]string, crioAnnotations map[string]string, annotations map[string]string, image string, imageName string, imageRef string, metadata *pb.ContainerMetadata, sandbox string, terminal bool, stdin bool, stdinOnce bool, privileged bool, runtimeHandler string, dir string, created time.Time, stopSignal string) (*Container, error) {
 	state := &ContainerState{}
 	state.Created = created
 	c := &Container{
@@ -94,7 +93,6 @@ func NewContainer(id string, name string, bundlePath string, logPath string, net
 		stdin:           stdin,
 		stdinOnce:       stdinOnce,
 		privileged:      privileged,
-		trusted:         trusted,
 		runtimeHandler:  runtimeHandler,
 		metadata:        metadata,
 		annotations:     annotations,

--- a/oci/container_test.go
+++ b/oci/container_test.go
@@ -153,7 +153,7 @@ var _ = t.Describe("Container", func() {
 		container, err := oci.NewContainer("", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
-			false, false, false, false, false, "", "", time.Now(), "SIGNO")
+			false, false, false, false, "", "", time.Now(), "SIGNO")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
 
@@ -169,7 +169,7 @@ var _ = t.Describe("Container", func() {
 		container, err := oci.NewContainer("", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
-			false, false, false, false, false, "", "", time.Now(), "")
+			false, false, false, false, "", "", time.Now(), "")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
 
@@ -186,7 +186,7 @@ var _ = t.Describe("Container", func() {
 		container, err := oci.NewContainer("", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
-			false, false, false, false, false, "", "", time.Now(), "")
+			false, false, false, false, "", "", time.Now(), "")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
 		container.SetState(nil)
@@ -204,7 +204,7 @@ var _ = t.Describe("Container", func() {
 		container, err := oci.NewContainer("", "", "", "", "",
 			map[string]string{}, map[string]string{}, map[string]string{},
 			"", "", "", &pb.ContainerMetadata{}, "",
-			false, false, false, false, false, "", "", time.Now(), "SIGTRAP")
+			false, false, false, false, "", "", time.Now(), "SIGTRAP")
 		Expect(err).To(BeNil())
 		Expect(container).NotTo(BeNil())
 

--- a/oci/oci_test.go
+++ b/oci/oci_test.go
@@ -12,9 +12,9 @@ var _ = t.Describe("Oci", func() {
 		It("should succeed with default runtime", func() {
 			// Given
 			// When
-			runtime, err := oci.New("", "", "", "runc",
+			runtime, err := oci.New("runc",
 				map[string]oci.RuntimeHandler{"runc": {"/bin/sh", ""}},
-				"", []string{}, "", "", "", 0, false, false, 0, "")
+				"", []string{}, "", "", "", 0, false, false, 0)
 
 			// Then
 			Expect(err).To(BeNil())
@@ -24,9 +24,9 @@ var _ = t.Describe("Oci", func() {
 		It("should fail if no runtime configured for default runtime", func() {
 			// Given
 			// When
-			runtime, err := oci.New("", "", "", "",
+			runtime, err := oci.New("",
 				map[string]oci.RuntimeHandler{}, "", []string{},
-				"", "", "", 0, false, false, 0, "")
+				"", "", "", 0, false, false, 0)
 
 			// Then
 			Expect(err).NotTo(BeNil())
@@ -40,9 +40,8 @@ var _ = t.Describe("Oci", func() {
 
 		// Test constants
 		const (
-			invalidRuntime     = "invalid"
-			defaultRuntime     = "runc"
-			runtimeTrustedPath = "runtimeTrustedPath"
+			invalidRuntime = "invalid"
+			defaultRuntime = "runc"
 		)
 		runtimes := map[string]oci.RuntimeHandler{
 			defaultRuntime: {"/bin/sh", ""}, invalidRuntime: {},
@@ -50,21 +49,12 @@ var _ = t.Describe("Oci", func() {
 
 		BeforeEach(func() {
 			var err error
-			sut, err = oci.New(runtimeTrustedPath, "", "", defaultRuntime,
+			sut, err = oci.New(defaultRuntime,
 				runtimes,
-				"", []string{}, "", "", "", 0, false, false, 0, "")
+				"", []string{}, "", "", "", 0, false, false, 0)
 
 			Expect(err).To(BeNil())
 			Expect(sut).NotTo(BeNil())
-		})
-
-		It("should succeed to retrieve the runtime base name", func() {
-			// Given
-			// When
-			result := sut.Name()
-
-			// Then
-			Expect(result).To(Equal(runtimeTrustedPath))
 		})
 
 		It("should succeed to retrieve the runtimes", func() {
@@ -84,22 +74,6 @@ var _ = t.Describe("Oci", func() {
 			// Then
 			Expect(err).To(BeNil())
 			Expect(handler).To(Equal(runtimes[defaultRuntime]))
-		})
-
-		It("should succeed to validate the untrusted runtime", func() {
-			// Given
-			const untrustedPath = "untrustedPath"
-			sut, err := oci.New("", untrustedPath, "", defaultRuntime,
-				runtimes, "", []string{}, "", "", "", 0, false, false, 0, "")
-			Expect(err).To(BeNil())
-			Expect(sut).NotTo(BeNil())
-
-			// When
-			handler, err := sut.ValidateRuntimeHandler(oci.UntrustedRuntime)
-
-			// Then
-			Expect(err).To(BeNil())
-			Expect(handler.RuntimePath).To(Equal(untrustedPath))
 		})
 
 		It("should fail to validate an inexisting runtime handler", func() {

--- a/oci/suite_test.go
+++ b/oci/suite_test.go
@@ -41,7 +41,7 @@ func getTestContainer() *oci.Container {
 		map[string]string{"key": "crioAnnotation"},
 		map[string]string{"key": "annotation"},
 		"image", "imageName", "imageRef", &pb.ContainerMetadata{}, "sandbox",
-		false, false, false, false, false, "", "dir", time.Now(), "")
+		false, false, false, false, "", "dir", time.Now(), "")
 	Expect(err).To(BeNil())
 	Expect(container).NotTo(BeNil())
 	return container

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -82,9 +82,6 @@ const (
 	// MountPoint is the mount point of the container rootfs
 	MountPoint = "io.kubernetes.cri-o.MountPoint"
 
-	// TrustedSandbox is the annotation for trusted sandboxes
-	TrustedSandbox = "io.kubernetes.cri-o.TrustedSandbox"
-
 	// RuntimeHandler is the annotation for runtime handler
 	RuntimeHandler = "io.kubernetes.cri-o.RuntimeHandler"
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -36,9 +36,6 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 		{c.APIConfig.StreamPort, "10010"},
 		{c.APIConfig.StreamAddress, "localhost"},
 
-		{c.RuntimeConfig.Runtime, "/usr/local/bin/runc"},
-		{c.RuntimeConfig.RuntimeUntrustedWorkload, ""},
-		{c.RuntimeConfig.DefaultWorkloadTrust, ""},
 		{c.RuntimeConfig.Conmon, "/usr/local/libexec/crio/conmon"},
 		{c.RuntimeConfig.ConmonEnv[0], "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		{c.RuntimeConfig.SELinux, true},

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -917,7 +917,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 
 	crioAnnotations := specgen.Spec().Annotations
 
-	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.NetNs().Path(), labels, crioAnnotations, kubeAnnotations, image, imageName, imageRef, metadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.Privileged(), sb.Trusted(), sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
+	container, err := oci.NewContainer(containerID, containerName, containerInfo.RunDir, logPath, sb.NetNs().Path(), labels, crioAnnotations, kubeAnnotations, image, imageName, imageRef, metadata, sb.ID(), containerConfig.Tty, containerConfig.Stdin, containerConfig.StdinOnce, sb.Privileged(), sb.RuntimeHandler(), containerInfo.Dir, created, containerImageConfig.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/inspect_test.go
+++ b/server/inspect_test.go
@@ -46,7 +46,7 @@ func TestGetContainerInfo(t *testing.T) {
 		"io.kubernetes.test1": "value1",
 	}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "image", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "image", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +163,7 @@ func TestGetContainerInfoCtrStateNil(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -194,7 +194,7 @@ func TestGetContainerInfoSandboxNotFound(t *testing.T) {
 	labels := map[string]string{}
 	annotations := map[string]string{}
 	getContainerFunc := func(id string) *oci.Container {
-		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, false, "", "/root/for/container", created, "SIGKILL")
+		container, err := oci.NewContainer("testid", "testname", "", "/container/logs", "", labels, annotations, annotations, "imageName", "imageName", "imageRef", &runtime.ContainerMetadata{}, "testsandboxid", false, false, false, false, "", "/root/for/container", created, "SIGKILL")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/kubernetes-sigs/cri-o/oci"
-	"github.com/kubernetes-sigs/cri-o/pkg/annotations"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
@@ -54,19 +53,6 @@ func (s *Server) privilegedSandbox(req *pb.RunPodSandboxRequest) bool {
 	}
 
 	return false
-}
-
-// trustedSandbox returns true if the sandbox will run trusted workloads.
-func (s *Server) trustedSandbox(req *pb.RunPodSandboxRequest) bool {
-	kubeAnnotations := req.GetConfig().GetAnnotations()
-
-	trustedAnnotation, ok := kubeAnnotations[annotations.TrustedSandbox]
-	if !ok {
-		// A sandbox is trusted by default.
-		return true
-	}
-
-	return isTrue(trustedAnnotation)
 }
 
 // runtimeHandler returns the runtime handler key provided by CRI if the key

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -327,7 +327,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		return nil, err
 	}
 
-	trusted := s.trustedSandbox(req)
 	g.AddAnnotation(annotations.Metadata, string(metadataJSON))
 	g.AddAnnotation(annotations.Labels, string(labelsJSON))
 	g.AddAnnotation(annotations.Annotations, string(kubeAnnotationsJSON))
@@ -340,7 +339,6 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.ContainerID, id)
 	g.AddAnnotation(annotations.ShmPath, shmPath)
 	g.AddAnnotation(annotations.PrivilegedRuntime, fmt.Sprintf("%v", privileged))
-	g.AddAnnotation(annotations.TrustedSandbox, fmt.Sprintf("%v", trusted))
 	g.AddAnnotation(annotations.RuntimeHandler, runtimeHandler)
 	g.AddAnnotation(annotations.ResolvPath, resolvPath)
 	g.AddAnnotation(annotations.HostName, hostname)
@@ -395,7 +393,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 		}
 	}
 
-	sb, err := sandbox.New(id, namespace, name, kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, trusted, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork)
+	sb, err := sandbox.New(id, namespace, name, kubeName, logDir, labels, kubeAnnotations, processLabel, mountLabel, metadata, shmPath, cgroupParent, privileged, runtimeHandler, resolvPath, hostname, portMappings, hostNetwork)
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +520,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.AddAnnotation(annotations.HostnamePath, hostnamePath)
 	sb.AddHostnamePath(hostnamePath)
 
-	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs().Path(), labels, g.Spec().Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.Trusted(), sb.RuntimeHandler(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
+	container, err := oci.NewContainer(id, containerName, podContainer.RunDir, logPath, sb.NetNs().Path(), labels, g.Spec().Annotations, kubeAnnotations, "", "", "", nil, id, false, false, false, sb.Privileged(), sb.RuntimeHandler(), podContainer.Dir, created, podContainer.Config.Config.StopSignal)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -50,10 +50,6 @@ const (
 	apparmorLocalHostPrefix = "localhost/"
 )
 
-func isTrue(annotaton string) bool {
-	return annotaton == "true"
-}
-
 // streamService implements streaming.Runtime.
 type streamService struct {
 	runtimeServer       *Server // needed by Exec() endpoint


### PR DESCRIPTION
As announced when RuntimeClass has been implemented as part of CRI-O,
the deprecated flags trusted/untrusted qualifying the workload will
be removed starting from 1.14.

This patch takes care of removing any reference to those annotations,
which simplifies greatly the code complexity.

Fixes #2139

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
