### PR TITLE
test: Update to golang 1.12.1

### DIFF
--- a/contrib/test/integration/main.yml
+++ b/contrib/test/integration/main.yml
@@ -50,7 +50,7 @@
     - name: install Golang tools
       include: golang.yml
       vars:
-          version: "1.12"
+          version: "1.12.1"
     - name: clone build and install cri-o
       include: "build/cri-o.yml"
   post_tasks:


### PR DESCRIPTION
k8s requires it for build now.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

