### PR TITLE
WIP: Update travis ostree to v2019.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - make install.tools
   - >
     if [ "${TRAVIS_OS_NAME}" = linux ]; then
-      OSTREE_VERSION=v2017.9;
+      OSTREE_VERSION=v2019.1;
       git clone https://github.com/ostreedev/ostree ${TRAVIS_BUILD_DIR}/ostree &&
       (
         cd ${TRAVIS_BUILD_DIR}/ostree &&


### PR DESCRIPTION
Some linters in travis have problems to successfully build the packages.

* https://travis-ci.org/kubernetes-sigs/cri-o/jobs/510848077

This PR updates the ostree dependency manually installed during the CI runs, which should fix the issue.