### PR TITLE
sandbox: fix segfault with manage_network_ns_lifecycle

### DIFF
--- a/lib/sandbox/sandbox.go
+++ b/lib/sandbox/sandbox.go
@@ -115,7 +115,7 @@ type NetNsIface interface {
 	Get() *NetNs
 
 	// Initialize does the necessary setup
-	Initialize() (*NetNs, error)
+	Initialize() (NetNsIface, error)
 
 	// Initialized returns true if already initialized
 	Initialized() bool
@@ -406,7 +406,7 @@ func (s *Sandbox) NetNsCreate(netNs NetNsIface) error {
 		return fmt.Errorf("net NS already initialized")
 	}
 
-	netNS, err := netNs.Initialize()
+	netNs, err := netNs.Initialize()
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func (s *Sandbox) NetNsCreate(netNs NetNsIface) error {
 		return err
 	}
 
-	s.netns = netNS
+	s.netns = netNs
 	return nil
 }
 

--- a/lib/sandbox/sandbox_linux.go
+++ b/lib/sandbox/sandbox_linux.go
@@ -26,13 +26,15 @@ func (n *NetNs) Initialized() bool {
 }
 
 // Initialize does the necessary setup for a NetNs
-func (n *NetNs) Initialize() (*NetNs, error) {
+func (n *NetNs) Initialize() (NetNsIface, error) {
 	netNS, err := ns.NewNS()
 	if err != nil {
 		return nil, err
 	}
-
-	return &NetNs{netNS: netNS, closed: false, initialized: true}, nil
+	n.netNS = netNS
+	n.closed = false
+	n.initialized = true
+	return n, nil
 }
 
 func getNetNs(path string) (*NetNs, error) {

--- a/lib/sandbox/sandbox_test.go
+++ b/lib/sandbox/sandbox_test.go
@@ -271,10 +271,9 @@ var _ = t.Describe("Sandbox", func() {
 			// Given
 			gomock.InOrder(
 				netNsIfaceMock.EXPECT().Initialized().Return(false),
-				netNsIfaceMock.EXPECT().Initialize().
-					Return(&sandbox.NetNs{}, nil),
-				netNsIfaceMock.EXPECT().SymlinkCreate(gomock.Any()).
-					Return(nil),
+				netNsIfaceMock.EXPECT().Initialize().Return(netNsIfaceMock, nil),
+				netNsIfaceMock.EXPECT().SymlinkCreate(gomock.Any()).Return(nil),
+				netNsIfaceMock.EXPECT().Remove().Return(nil),
 			)
 
 			// When
@@ -282,7 +281,7 @@ var _ = t.Describe("Sandbox", func() {
 
 			// Then
 			Expect(err).To(BeNil())
-			Expect(testSandbox.NetNsRemove()).NotTo(BeNil())
+			Expect(testSandbox.NetNsRemove()).To(BeNil())
 		})
 
 		It("should not crash when parameter is nil", func() {
@@ -298,7 +297,7 @@ var _ = t.Describe("Sandbox", func() {
 			gomock.InOrder(
 				netNsIfaceMock.EXPECT().Initialized().Return(false),
 				netNsIfaceMock.EXPECT().Initialize().
-					Return(&sandbox.NetNs{}, nil),
+					Return(netNsIfaceMock, nil),
 				netNsIfaceMock.EXPECT().SymlinkCreate(gomock.Any()).
 					Return(t.TestError),
 				netNsIfaceMock.EXPECT().Close().Return(nil),
@@ -316,7 +315,7 @@ var _ = t.Describe("Sandbox", func() {
 			gomock.InOrder(
 				netNsIfaceMock.EXPECT().Initialized().Return(false),
 				netNsIfaceMock.EXPECT().Initialize().
-					Return(&sandbox.NetNs{}, nil),
+					Return(netNsIfaceMock, nil),
 				netNsIfaceMock.EXPECT().SymlinkCreate(gomock.Any()).
 					Return(t.TestError),
 				netNsIfaceMock.EXPECT().Close().Return(t.TestError),
@@ -375,7 +374,7 @@ var _ = t.Describe("Sandbox", func() {
 			gomock.InOrder(
 				netNsIfaceMock.EXPECT().Initialized().Return(false),
 				netNsIfaceMock.EXPECT().Initialize().
-					Return(&sandbox.NetNs{}, nil),
+					Return(netNsIfaceMock, nil),
 				netNsIfaceMock.EXPECT().SymlinkCreate(gomock.Any()).
 					Return(nil),
 			)
@@ -384,6 +383,9 @@ var _ = t.Describe("Sandbox", func() {
 
 		It("should succeed", func() {
 			// Given
+			gomock.InOrder(
+				netNsIfaceMock.EXPECT().Get().Return(&sandbox.NetNs{}),
+			)
 			// When
 			ns, err := testSandbox.NetNsGet("/proc/self/ns",
 				"../../../tmp/test")
@@ -401,6 +403,9 @@ var _ = t.Describe("Sandbox", func() {
 
 		It("should succeed with symlink", func() {
 			// Given
+			gomock.InOrder(
+				netNsIfaceMock.EXPECT().Get().Return(&sandbox.NetNs{}),
+			)
 			const link = "ns-link"
 			Expect(os.Symlink("/proc/self/ns", link)).To(BeNil())
 			defer os.RemoveAll(link)

--- a/test/mocks/sandbox/sandbox.go
+++ b/test/mocks/sandbox/sandbox.go
@@ -62,10 +62,10 @@ func (mr *MockNetNsIfaceMockRecorder) Get() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockNetNsIface) Initialize() (*sandbox.NetNs, error) {
+func (m *MockNetNsIface) Initialize() (sandbox.NetNsIface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize")
-	ret0, _ := ret[0].(*sandbox.NetNs)
+	ret0, _ := ret[0].(sandbox.NetNsIface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
fix this segfault:

github.com/kubernetes-sigs/cri-o/lib/sandbox.(*NetNs).SymlinkCreate(0xc0002107b0, 0xc000882180, 0x40, 0x0, 0xc000210690)
       src/github.com/kubernetes-sigs/cri-o/lib/sandbox/sandbox_linux.go:68 +0x1d2
github.com/kubernetes-sigs/cri-o/lib/sandbox.(*Sandbox).NetNsCreate(0xc0002a4000, 0x1d042a0, 0xc0002107b0, 0x1c, 0xc0003e2b08)
       src/github.com/kubernetes-sigs/cri-o/lib/sandbox/sandbox.go:414 +0x166
github.com/kubernetes-sigs/cri-o/server.(*Server).runPodSandbox(0xc0003d0480, 0x1cf14c0, 0xc0007fcd20, 0xc0005a28e0, 0x0, 0x0, 0x0)
       src/github.com/kubernetes-sigs/cri-o/server/sandbox_run_linux.go:460 +0x698c
github.com/kubernetes-sigs/cri-o/server.(*Server).RunPodSandbox(0xc0003d0480, 0x1cf14c0, 0xc0007fcd20, 0xc0005a28e0, 0xc0003d0480, 0x7f8028c0cc00, 0xc000229c28)
       src/github.com/kubernetes-sigs/cri-o/server/sandbox_run.go:122 +0x49
github.com/kubernetes-sigs/cri-o/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2._RuntimeService_RunPodSandbox_Handler(0x1a017a0, 0xc0003d0480, 0x1cf14c0, 0xc0007fcd20, 0xc00017d0e0, 0x0, 0x0, 0x0, 0x0, 0x0)

regression introduced by: 26b177d8c24982c979ff81c02f20857f955ec708

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
