### PR TITLE
Small tweaks to journald logging

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -44,6 +44,7 @@ static gboolean opt_leave_stdin_open = FALSE;
 static gboolean opt_syslog = FALSE;
 static char *opt_cid = NULL;
 static char *opt_cuuid = NULL;
+static char *opt_name = NULL;
 static char *opt_runtime_path = NULL;
 static char *opt_bundle_path = NULL;
 static char *opt_container_pid_file = NULL;
@@ -71,6 +72,7 @@ static GOptionEntry opt_entries[] = {
 	{"leave-stdin-open", 0, 0, G_OPTION_ARG_NONE, &opt_leave_stdin_open, "Leave stdin open when attached client disconnects", NULL},
 	{"cid", 'c', 0, G_OPTION_ARG_STRING, &opt_cid, "Container ID", NULL},
 	{"cuuid", 'u', 0, G_OPTION_ARG_STRING, &opt_cuuid, "Container UUID", NULL},
+	{"name", 'n', 0, G_OPTION_ARG_STRING, &opt_name, "Container name", NULL},
 	{"runtime", 'r', 0, G_OPTION_ARG_STRING, &opt_runtime_path, "Runtime path", NULL},
 	{"restore", 0, 0, G_OPTION_ARG_STRING, &opt_restore_path, "Restore a container from a checkpoint", NULL},
 	{"restore-arg", 0, 0, G_OPTION_ARG_STRING_ARRAY, &opt_restore_args,
@@ -329,6 +331,9 @@ static bool read_stdio(int fd, stdpipe_t pipe, gboolean *eof)
 		nwarnf("stdio_input read failed %s", strerror(errno));
 		return false;
 	} else {
+		// Always null terminate the buffer, just in case.
+		buf[num_read] = '\0';
+
 		bool written = write_to_logs(pipe, buf, num_read);
 		if (!written)
 			return written;
@@ -975,7 +980,6 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
-	// why not nexit?
 	if (opt_cid == NULL) {
 		fprintf(stderr, "Container ID not provided. Use --cid\n");
 		exit(EXIT_FAILURE);
@@ -989,6 +993,9 @@ int main(int argc, char *argv[])
 
 	if (!opt_exec && opt_cuuid == NULL)
 		nexit("Container UUID not provided. Use --cuuid");
+
+	if (opt_name == NULL)
+		nexit("Container name not provided. Use --name");
 
 	if (opt_runtime_path == NULL)
 		nexit("Runtime path not provided. Use --runtime");
@@ -1019,7 +1026,7 @@ int main(int argc, char *argv[])
 		opt_container_pid_file = default_pid_file;
 	}
 
-	configure_log_drivers(opt_log_path, opt_log_size_max, opt_cuuid);
+	configure_log_drivers(opt_log_path, opt_log_size_max, opt_cuuid, opt_name);
 
 	start_pipe_fd = get_pipe_fd_from_env("_OCI_STARTPIPE");
 	if (start_pipe_fd >= 0) {

--- a/conmon/ctr_logging.c
+++ b/conmon/ctr_logging.c
@@ -6,9 +6,10 @@
 #ifdef USE_JOURNALD
 #include <systemd/sd-journal.h>
 #else
-// this function should never be used, as journald logging is disabled and
-// parsing code errors if USE_JOURNALD isn't flagged.
-// This is just to make the compiler happy and the other code prettier
+/* this function should never be used, as journald logging is disabled and
+ * parsing code errors if USE_JOURNALD isn't flagged.
+ * This is just to make the compiler happy and the other code prettier
+ */
 static inline int sd_journal_send(char *fmt, ...)
 {
 	perror(fmt);
@@ -19,7 +20,6 @@ static inline int sd_journal_send(char *fmt, ...)
 
 /* strlen("1997-03-25T13:20:42.999999999+01:00 stdout ") + 1 */
 #define TSBUFLEN 44
-
 
 /* Different types of container logging */
 static gboolean use_journald_logging = FALSE;
@@ -46,6 +46,7 @@ static void parse_log_path(char *log_config);
 static const char *stdpipe_name(stdpipe_t pipe);
 static int write_journald(int pipe, char *buf, ssize_t num_read);
 static int write_k8s_log(stdpipe_t pipe, const char *buf, ssize_t buflen);
+static bool get_line_len(ptrdiff_t *line_len, const char *buf, ssize_t buflen);
 static ssize_t writev_buffer_append_segment(int fd, writev_buffer_t *buf, const void *data, ssize_t len);
 static ssize_t writev_buffer_flush(int fd, writev_buffer_t *buf);
 static int set_k8s_timestamp(char *buf, ssize_t buflen, const char *pipename);
@@ -129,13 +130,38 @@ bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read)
 /* write to systemd journal. If the pipe is stdout, write with notice priority,
  * otherwise, write with error priority
  */
-int write_journald(int pipe, char *buf, G_GNUC_UNUSED ssize_t num_read)
+int write_journald(int pipe, char *buf, ssize_t buflen)
 {
 	int message_priority = LOG_INFO;
 	if (pipe == STDERR_PIPE)
 		message_priority = LOG_ERR;
-	sd_journal_send("MESSAGE=%s", buf, "PRIORITY=%i", message_priority, "CONTAINER_ID_FULL=%s", cuuid, "CONTAINER_ID=%s", short_cuuid,
-			"CONTAINER_NAME=%s", name, NULL);
+
+	ptrdiff_t line_len = 0;
+	while (buflen > 0) {
+		bool partial = get_line_len(&line_len, buf, buflen);
+		/* sd_journal_* doesn't have an option to specify the number of bytes to write, and instead writes the
+		 * entire string. Copying every line doesn't make very much sense, so instead we do this tmp_line_end
+		 * hack to emulate separate strings.
+		 */
+		char tmp_line_end = buf[line_len];
+		buf[line_len] = '\0';
+
+		/* per docker journald logging format, CONTAINER_PARTIAL_MESSAGE is set to true if it's partial, but otherwise not set.
+		 * hence the two cases
+		 */
+		if (partial) {
+			sd_journal_send("MESSAGE=%s", buf, "PRIORITY=%i", message_priority, "CONTAINER_ID_FULL=%s", cuuid,
+					"CONTAINER_ID=%s", short_cuuid, "CONTAINER_NAME=%s", name, "CONTAINER_PARTIAL_MESSAGE=%s", "true",
+					NULL);
+		} else {
+			sd_journal_send("MESSAGE=%s", buf, "PRIORITY=%i", message_priority, "CONTAINER_ID_FULL=%s", cuuid,
+					"CONTAINER_ID=%s", short_cuuid, "CONTAINER_NAME=%s", name, NULL);
+		}
+		buf[line_len] = tmp_line_end;
+
+		buf += line_len;
+		buflen -= line_len;
+	}
 	return 0;
 }
 
@@ -161,18 +187,9 @@ static int write_k8s_log(stdpipe_t pipe, const char *buf, ssize_t buflen)
 		/* TODO: We should handle failures much more cleanly than this. */
 		return -1;
 
+	ptrdiff_t line_len = 0;
 	while (buflen > 0) {
-		const char *line_end = NULL;
-		ptrdiff_t line_len = 0;
-		bool partial = FALSE;
-
-		/* Find the end of the line, or alternatively the end of the buffer. */
-		line_end = memchr(buf, '\n', buflen);
-		if (line_end == NULL) {
-			line_end = &buf[buflen - 1];
-			partial = TRUE;
-		}
-		line_len = line_end - buf + 1;
+		bool partial = get_line_len(&line_len, buf, buflen);
 
 		/* This is line_len bytes + TSBUFLEN - 1 + 2 (- 1 is for ignoring \0). */
 		bytes_to_be_written = line_len + TSBUFLEN + 1;
@@ -247,6 +264,22 @@ static int write_k8s_log(stdpipe_t pipe, const char *buf, ssize_t buflen)
 
 	return 0;
 }
+
+/* Find the end of the line, or alternatively the end of the buffer.
+ * Returns false in the former case (it's a whole line) or true in the latter (it's a partial)
+ */
+static bool get_line_len(ptrdiff_t *line_len, const char *buf, ssize_t buflen)
+{
+	bool partial = FALSE;
+	const char *line_end = memchr(buf, '\n', buflen);
+	if (line_end == NULL) {
+		line_end = &buf[buflen - 1];
+		partial = TRUE;
+	}
+	*line_len = line_end - buf + 1;
+	return partial;
+}
+
 
 static ssize_t writev_buffer_flush(int fd, writev_buffer_t *buf)
 {

--- a/conmon/ctr_logging.h
+++ b/conmon/ctr_logging.h
@@ -7,7 +7,7 @@
 
 void reopen_log_files(void);
 bool write_to_logs(stdpipe_t pipe, char *buf, ssize_t num_read);
-void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, char *cuuid_);
+void configure_log_drivers(gchar **log_drivers, int64_t log_size_max_, char *cuuid_, char *name_);
 void sync_logs(void);
 
 #endif /* !defined(CTR_LOGGING_H) */

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -81,6 +81,7 @@ func (r *runtimeOCI) CreateContainer(c *Container, cgroupParent string) (err err
 	}
 
 	args = append(args, "-c", c.id)
+	args = append(args, "-n", c.name)
 	args = append(args, "-u", c.id)
 	args = append(args, "-r", r.path)
 	args = append(args, "-b", c.bundlePath)
@@ -343,6 +344,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	var args []string
 	args = append(args, "-c", c.id)
+	args = append(args, "-n", c.name)
 	args = append(args, "-r", r.path)
 	args = append(args, "-p", pidFile.Name())
 	args = append(args, "-e")

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -319,9 +319,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# priority of 5 is LOG_NOTICE
-	journalctl -t conmon -p notice MESSAGE_ID="$ctr_id" | grep -E "$stdout"
+	journalctl -t conmon -p info CONTAINER_ID_FULL="$ctr_id" | grep -E "$stdout"
 	# priority of 3 is LOG_ERR
-	journalctl -t conmon -p err MESSAGE_ID="$ctr_id" | grep -E "$stderr"
+	journalctl -t conmon -p err CONTAINER_ID_FULL="$ctr_id" | grep -E "$stderr"
 
 	run crictl stopp "$pod_id"
 	echo "$output"


### PR DESCRIPTION
Two changes to better match docker functionality:
	Change MESSAGE_ID to CONTAINER_ID_FULL, as well as add CONTAINER_ID (truncated at 12 characters)
	Change stdout output to an info instead of a notice log level
Also small change with where the log buffer is null terminated
	Now, the callee doesn't depend on an unchecked invariant that num_read < strlen(buf)

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
