### PR TITLE
Update toml decode errors to be more precise

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -327,7 +327,7 @@ func (c *Config) UpdateFromFile(path string) error {
 
 	_, err = toml.Decode(string(data), t)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to decode configuration %v: %v", path, err)
 	}
 
 	t.toConfig(c)

--- a/server/config.go
+++ b/server/config.go
@@ -101,7 +101,7 @@ func (c *Config) UpdateFromFile(path string) error {
 
 	_, err = toml.Decode(string(data), t)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to decode configuration %v: %v", path, err)
 	}
 
 	t.toConfig(c)


### PR DESCRIPTION
Hey, this is just a small change to increase the customer satisfaction and abort with a more meaningful error in case of configuration issues.