### PR TITLE
[1.11] Pick up correct gid

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -532,7 +532,11 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 		if sc.GetRunAsUser() == nil && sc.GetRunAsUsername() == "" && sc.GetRunAsGroup() != nil {
 			return fmt.Errorf("RunAsGroup should be specified only with RunAsUser or RunAsUsername")
 		}
-		groupstr := strconv.FormatInt(sc.GetRunAsGroup().GetValue(), 10)
+
+		var groupstr string
+		if sc.GetRunAsGroup() != nil {
+			groupstr = strconv.FormatInt(sc.GetRunAsGroup().GetValue(), 10)
+		}
 		if groupstr != "" {
 			containerUser = containerUser + ":" + groupstr
 		}

--- a/test/testdata/container_redis_user.json
+++ b/test/testdata/container_redis_user.json
@@ -1,0 +1,71 @@
+{
+	"metadata": {
+		"name": "podsandbox1-redis"
+	},
+	"image": {
+		"image": "quay.io/crio/redis:alpine"
+	},
+	"command": [
+        "sleep",
+        "1000"
+	],
+	"args": [],
+	"working_dir": "/data",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		},
+		{
+			"key": "TERM",
+			"value": "xterm"
+		},
+		{
+			"key": "REDIS_VERSION",
+			"value": "3.2.3"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_URL",
+			"value": "http://download.redis.io/releases/redis-3.2.3.tar.gz"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_SHA1",
+			"value": "92d6d93ef2efc91e595c8bf578bf72baff397507"
+		}
+	],
+	"labels": {
+		"tier": "backend"
+	},
+	"annotations": {
+		"pod": "podsandbox1"
+	},
+	"readonly_rootfs": false,
+	"log_path": "",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"resources": {
+			"memory_limit_in_bytes": 209715200,
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"oom_score_adj": 30,
+			"cpuset_cpus": "0",
+			"cpuset_mems": "0"
+		},
+		"security_context": {
+			"run_as_user": {
+				"value": 100
+			},
+			"namespace_options": {
+				"pid": 1
+			},
+			"capabilities": {
+				"add_capabilities": [
+					"sys_admin"
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
When setting the gid, we were not checking if RunAsGroup
from k8s was nil or not. We were simply converting that
to an int and nil was becoming 0. Hence all the containers
were being run with gid root regardless of their uid.
Adding that check here fixes it and we get the correct gid.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>