### PR TITLE
Enhance config validation

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/kubernetes-sigs/cri-o/lib"
 	"github.com/kubernetes-sigs/cri-o/oci"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -153,7 +154,11 @@ func (c *Config) Validate(onExecution bool) error {
 	}
 
 	if err := c.RuntimeConfig.Validate(onExecution); err != nil {
-		return err
+		return errors.Wrapf(err, "config validation")
+	}
+
+	if err := c.NetworkConfig.Validate(onExecution); err != nil {
+		return errors.Wrapf(err, "config validation")
 	}
 
 	if c.UIDMappings != "" && c.ManageNetworkNSLifecycle {

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -103,7 +103,11 @@ func TestConfigValidateDefaultSuccessOnExecution(t *testing.T) {
 
 	// since some test systems do not have runc installed, assume a more
 	// generally available executable
-	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: "/bin/sh"}
+	const validPath = "/bin/sh"
+	defaultConfig.Runtimes["runc"] = oci.RuntimeHandler{RuntimePath: validPath}
+	defaultConfig.Conmon = validPath
+	defaultConfig.NetworkConfig.NetworkDir = validPath
+	defaultConfig.NetworkConfig.PluginDir = []string{validPath}
 
 	must(t, defaultConfig.Validate(true))
 }


### PR DESCRIPTION
This commit updates to config validation on cri-o startup to work for:

- `RuntimeConfig.HooksDir`
- `RuntimeConfig.Conmon`
- `NetworkConfig.NetworkDir`
- `NetworkConfig.PluginDir`

All unit tests have been updated as well, whereas the returned error now
indicates that the issue happened on "config validation".