### PR TITLE
[master] Fix possible out of bounds access during container log parsing

### DIFF
--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -247,7 +247,7 @@ func parseLog(log []byte) (stdout, stderr []byte) {
 		linetype := string(parts[2])
 		if linetype == "P" {
 			contentLen := len(content)
-			if content[contentLen-1] == '\n' {
+			if contentLen > 0 && content[contentLen-1] == '\n' {
 				content = content[:contentLen-1]
 			}
 		}


### PR DESCRIPTION
The OCI runtime `parseLog()` function is currently called by `ExecSyncContainer()` and the RPC entry point `ExecSync()`.

A temporarily log file within `/tmp/crio-log-$CONTAINERID` is created during the execution of `ExecSync()`, which receives the stdout and stderr output from the provided command.

This commit fixes an index out-of-bounds runtime panic if the log file contains an malicious partial (P) log entry which does not contain a newline at the end of the file, like `2019-03-28T10:24:43.981274081+01:00 stdout P `.

The issue can be reproduced like this:

1. Force creating the logfile in `/tmp` via:
   ```
   > sudo crictl exec -s $CONTAINERID sh -c "echo test && sleep 30"
   ```
2. Modify the logfile with malicious content:
   ```
   > echo -n "2019-03-28T10:24:43.981274081+01:00 stdout P " >> /tmp/crio-log-$CONTAINERID
   ```
3. Wait for the crash

The issue tracks down to v1.9.0, should I backport the fix to the related release branches?
