### PR TITLE
[1.11] Fix possible out of bounds access during log parsing

### DIFF
--- a/oci/oci.go
+++ b/oci/oci.go
@@ -356,7 +356,7 @@ func parseLog(log []byte) (stdout, stderr []byte) {
 		linetype := string(parts[2])
 		if linetype == "P" {
 			contentLen := len(content)
-			if content[contentLen-1] == '\n' {
+			if contentLen > 0 && content[contentLen-1] == '\n' {
 				content = content[:contentLen-1]
 			}
 		}


### PR DESCRIPTION
This PR backports #2180