### PR TITLE
[1.14] Fix possible out of bounds access during log parsing

### DIFF
--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -247,7 +247,7 @@ func parseLog(log []byte) (stdout, stderr []byte) {
 		linetype := string(parts[2])
 		if linetype == "P" {
 			contentLen := len(content)
-			if content[contentLen-1] == '\n' {
+			if contentLen > 0 && content[contentLen-1] == '\n' {
 				content = content[:contentLen-1]
 			}
 		}


### PR DESCRIPTION
This PR backports #2180