### PR TITLE
Update linter to use hugeParam

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,11 +59,11 @@ linters-settings:
 
       # Performance
       - equalFold
+      - hugeParam
       - indexAlloc
       - rangeExprCopy
       - rangeValCopy
       # - appendCombine
-      # - hugeParam
 
       # Style
       - assignOp

--- a/lib/container_server.go
+++ b/lib/container_server.go
@@ -401,7 +401,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	// We add a netNS only if we can load a permanent one.
 	// Otherwise, the sandbox will live in the host namespace.
 	if c.config.ManageNetworkNSLifecycle {
-		netNsPath, err := configNetNsPath(m)
+		netNsPath, err := configNetNsPath(&m)
 		if err == nil {
 			nsErr := sb.NetNsJoin(netNsPath, sb.Name())
 			// If we can't load the networking namespace
@@ -479,7 +479,7 @@ func (c *ContainerServer) LoadSandbox(id string) error {
 	return nil
 }
 
-func configNetNsPath(spec rspec.Spec) (string, error) {
+func configNetNsPath(spec *rspec.Spec) (string, error) {
 	for _, ns := range spec.Linux.Namespaces {
 		if ns.Type != rspec.NetworkNamespace {
 			continue

--- a/oci/oci.go
+++ b/oci/oci.go
@@ -425,6 +425,6 @@ type ExecSyncError struct {
 	Err      error
 }
 
-func (e ExecSyncError) Error() string {
+func (e *ExecSyncError) Error() string {
 	return fmt.Sprintf("command error: %+v, stdout: %s, stderr: %s, exit code %d", e.Err, e.Stdout.Bytes(), e.Stderr.Bytes(), e.ExitCode)
 }

--- a/oci/runtime_oci.go
+++ b/oci/runtime_oci.go
@@ -316,7 +316,7 @@ func (r *runtimeOCI) ExecContainer(c *Container, cmd []string, stdin io.Reader, 
 func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout int64) (resp *ExecSyncResponse, err error) {
 	pidFile, parentPipe, childPipe, err := prepareExec()
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			ExitCode: -1,
 			Err:      err,
 		}
@@ -330,7 +330,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	logFile, err := ioutil.TempFile("", "crio-log-"+c.id)
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			ExitCode: -1,
 			Err:      err,
 		}
@@ -359,7 +359,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	processFile, err := prepareProcessExec(c, command, c.terminal)
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			ExitCode: -1,
 			Err:      err,
 		}
@@ -380,7 +380,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	err = cmd.Start()
 	if err != nil {
 		childPipe.Close()
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: -1,
@@ -393,7 +393,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	err = cmd.Wait()
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: getExitCode(err),
@@ -403,7 +403,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	var ec *exitCodeInfo
 	if err := json.NewDecoder(parentPipe).Decode(&ec); err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: -1,
@@ -414,7 +414,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 	logrus.Debugf("Received container exit code: %v, message: %s", ec.ExitCode, ec.Message)
 
 	if ec.ExitCode == -1 {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: -1,
@@ -430,7 +430,7 @@ func (r *runtimeOCI) ExecSyncContainer(c *Container, command []string, timeout i
 
 	logBytes, err := ioutil.ReadFile(logPath)
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			Stdout:   stdoutBuf,
 			Stderr:   stderrBuf,
 			ExitCode: -1,

--- a/oci/runtime_vm.go
+++ b/oci/runtime_vm.go
@@ -282,7 +282,7 @@ func (r *runtimeVM) ExecSyncContainer(c *Container, command []string, timeout in
 
 	exitCode, err := r.execContainerCommon(c, command, timeout, nil, stdout, stderr, c.terminal, nil)
 	if err != nil {
-		return nil, ExecSyncError{
+		return nil, &ExecSyncError{
 			ExitCode: -1,
 			Err:      errors.Wrapf(err, "ExecSyncContainer failed"),
 		}

--- a/pkg/seccomp/seccomp.go
+++ b/pkg/seccomp/seccomp.go
@@ -30,14 +30,14 @@ func IsEnabled() bool {
 }
 
 // LoadProfileFromStruct takes a Seccomp struct and setup seccomp in the spec.
-func LoadProfileFromStruct(config Seccomp, specgen *generate.Generator) error {
+func LoadProfileFromStruct(config *Seccomp, specgen *generate.Generator) error {
 	return setupSeccomp(config, specgen)
 }
 
 // LoadProfileFromBytes takes a byte slice and decodes the seccomp profile.
 func LoadProfileFromBytes(body []byte, specgen *generate.Generator) error {
-	var config Seccomp
-	if err := json.Unmarshal(body, &config); err != nil {
+	config := &Seccomp{}
+	if err := json.Unmarshal(body, config); err != nil {
 		return fmt.Errorf("decoding seccomp profile failed: %v", err)
 	}
 	return setupSeccomp(config, specgen)
@@ -53,7 +53,7 @@ var nativeToSeccomp = map[string]Arch{
 	"s390x":       ArchS390X,
 }
 
-func setupSeccomp(config Seccomp, specgen *generate.Generator) error {
+func setupSeccomp(config *Seccomp, specgen *generate.Generator) error {
 	// No default action specified, no syscalls listed, assume seccomp disabled
 	if config.DefaultAction == "" && len(config.Syscalls) == 0 {
 		return nil

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -49,7 +49,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should succeed to load", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{},
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{},
 				&generate.Generator{})
 
 			// Then
@@ -62,7 +62,7 @@ var _ = t.Describe("Seccomp", func() {
 			Expect(err).To(BeNil())
 
 			// When
-			err = seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err = seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Syscalls: []*seccomp.Syscall{
 					{Excludes: seccomp.Filter{
@@ -97,7 +97,7 @@ var _ = t.Describe("Seccomp", func() {
 			arch := seccomp.ArchX86_64
 
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				ArchMap: []seccomp.Architecture{
 					{arch, []seccomp.Arch{seccomp.Arch("arch")}},
@@ -114,7 +114,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should fail to load on invalid data", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Architectures: []seccomp.Arch{seccomp.Arch("arch")},
 				ArchMap: []seccomp.Architecture{{
@@ -129,7 +129,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should fail to load on given `name` and `names`", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Syscalls: []*seccomp.Syscall{
 					{Name: "name", Names: []string{"name"}},
@@ -150,7 +150,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should fail on nil generator", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Syscalls:      []*seccomp.Syscall{{Name: "name"}}},
 				nil)
@@ -162,7 +162,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should fail on empty generator", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Syscalls:      []*seccomp.Syscall{{Name: "name"}}},
 				&generate.Generator{})
@@ -174,7 +174,7 @@ var _ = t.Describe("Seccomp", func() {
 		It("should fail on empty generator config", func() {
 			// Given
 			// When
-			err := seccomp.LoadProfileFromStruct(seccomp.Seccomp{
+			err := seccomp.LoadProfileFromStruct(&seccomp.Seccomp{
 				DefaultAction: "action",
 				Syscalls:      []*seccomp.Syscall{{Name: "name"}}},
 				&generate.Generator{Config: &specs.Spec{}})

--- a/pkg/seccomp/seccomp_unsupported.go
+++ b/pkg/seccomp/seccomp_unsupported.go
@@ -10,7 +10,7 @@ func IsEnabled() bool {
 }
 
 // LoadProfileFromStruct takes a Seccomp struct and setup seccomp in the spec.
-func LoadProfileFromStruct(config Seccomp, specgen *generate.Generator) error {
+func LoadProfileFromStruct(config *Seccomp, specgen *generate.Generator) error {
 	return nil
 }
 

--- a/pkg/storage/runtime.go
+++ b/pkg/storage/runtime.go
@@ -83,7 +83,7 @@ type RuntimeServer interface {
 	// GetContainerMetadata returns the metadata we've stored for a container.
 	GetContainerMetadata(idOrName string) (RuntimeContainerMetadata, error)
 	// SetContainerMetadata updates the metadata we've stored for a container.
-	SetContainerMetadata(idOrName string, metadata RuntimeContainerMetadata) error
+	SetContainerMetadata(idOrName string, metadata *RuntimeContainerMetadata) error
 
 	// CreateContainer creates a container with the specified ID.
 	// Pointer arguments can be nil.  Either the image name or ID can be
@@ -377,7 +377,7 @@ func (r *runtimeService) DeleteContainer(idOrName string) error {
 	return nil
 }
 
-func (r *runtimeService) SetContainerMetadata(idOrName string, metadata RuntimeContainerMetadata) error {
+func (r *runtimeService) SetContainerMetadata(idOrName string, metadata *RuntimeContainerMetadata) error {
 	mdata, err := json.Marshal(&metadata)
 	if err != nil {
 		logrus.Debugf("failed to encode metadata for %q: %v", idOrName, err)

--- a/pkg/storage/runtime_test.go
+++ b/pkg/storage/runtime_test.go
@@ -383,7 +383,7 @@ var _ = t.Describe("Runtime", func() {
 	t.Describe("SetContainerMetadata", func() {
 		It("should succeed to set the container metadata", func() {
 			// Given
-			metadata := storage.RuntimeContainerMetadata{Pod: true}
+			metadata := &storage.RuntimeContainerMetadata{Pod: true}
 			metadata.SetMountLabel("label")
 			gomock.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
@@ -400,7 +400,7 @@ var _ = t.Describe("Runtime", func() {
 
 		It("should fail to set the container on store error", func() {
 			// Given
-			metadata := storage.RuntimeContainerMetadata{Pod: true}
+			metadata := &storage.RuntimeContainerMetadata{Pod: true}
 			gomock.InOrder(
 				imageServerMock.EXPECT().GetStore().Return(storeMock),
 				storeMock.EXPECT().SetMetadata(gomock.Any(), gomock.Any()).

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -23,7 +23,7 @@ func fails(t *testing.T, err error) {
 	}
 }
 
-func assertAllFieldsEquality(t *testing.T, c Config) {
+func assertAllFieldsEquality(t *testing.T, c *Config) {
 	testCases := []struct {
 		fieldValue, expected interface{}
 	}{
@@ -64,7 +64,7 @@ func assertAllFieldsEquality(t *testing.T, c Config) {
 }
 
 func TestUpdateFromFile(t *testing.T) {
-	c := Config{}
+	c := &Config{}
 
 	must(t, c.UpdateFromFile(fixturePath))
 
@@ -84,7 +84,7 @@ func TestToFile(t *testing.T) {
 
 	must(t, configFromFixture.ToFile(f.Name()))
 
-	writtenConfig := Config{}
+	writtenConfig := &Config{}
 	err = writtenConfig.UpdateFromFile(f.Name())
 	if err != nil {
 		t.Fatal(err)

--- a/server/container_create.go
+++ b/server/container_create.go
@@ -623,7 +623,7 @@ func (s *Server) setupSeccomp(specgen *generate.Generator, profile string) error
 		return nil
 	}
 	if profile == seccompRuntimeDefault || profile == seccompDockerDefault {
-		return seccomp.LoadProfileFromStruct(s.seccompProfile, specgen)
+		return seccomp.LoadProfileFromStruct(&s.seccompProfile, specgen)
 	}
 	if !strings.HasPrefix(profile, seccompLocalhostPrefix) {
 		return fmt.Errorf("unknown seccomp profile option: %q", profile)

--- a/server/container_create_linux.go
+++ b/server/container_create_linux.go
@@ -308,7 +308,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	specgen.HostSpecific = true
 	specgen.ClearProcessRlimits()
 
-	ulimits, err := getUlimitsFromConfig(s.config)
+	ulimits, err := getUlimitsFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (s *Server) createSandboxContainer(ctx context.Context, containerID string,
 	// Add cgroup mount so container process can introspect its own limits
 	specgen.AddMount(mnt)
 
-	devices, err := getDevicesFromConfig(s.config)
+	devices, err := getDevicesFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}
@@ -1130,7 +1130,7 @@ func addOCIBindMounts(mountLabel string, containerConfig *pb.ContainerConfig, sp
 	return volumes, ociMounts, nil
 }
 
-func getDevicesFromConfig(config Config) ([]rspec.LinuxDevice, error) {
+func getDevicesFromConfig(config *Config) ([]rspec.LinuxDevice, error) {
 	linuxdevs := make([]rspec.LinuxDevice, 0, len(config.RuntimeConfig.AdditionalDevices))
 	for _, d := range config.RuntimeConfig.AdditionalDevices {
 		src, dst, permissions, err := createconfig.ParseDevice(d)

--- a/server/sandbox_run.go
+++ b/server/sandbox_run.go
@@ -164,7 +164,7 @@ func (s *Server) setPodSandboxMountLabel(id, mountLabel string) error {
 		return err
 	}
 	storageMetadata.SetMountLabel(mountLabel)
-	return s.StorageRuntimeServer().SetContainerMetadata(id, storageMetadata)
+	return s.StorageRuntimeServer().SetContainerMetadata(id, &storageMetadata)
 }
 
 func getSELinuxLabels(selinuxOptions *pb.SELinuxOption, privileged bool) (string, string, error) {

--- a/server/sandbox_run_linux.go
+++ b/server/sandbox_run_linux.go
@@ -131,7 +131,7 @@ func (s *Server) runPodSandbox(ctx context.Context, req *pb.RunPodSandboxRequest
 	g.HostSpecific = true
 	g.ClearProcessRlimits()
 
-	ulimits, err := getUlimitsFromConfig(s.config)
+	ulimits, err := getUlimitsFromConfig(&s.config)
 	if err != nil {
 		return nil, err
 	}

--- a/server/utils.go
+++ b/server/utils.go
@@ -258,7 +258,7 @@ type ulimit struct {
 	soft uint64
 }
 
-func getUlimitsFromConfig(config Config) ([]ulimit, error) {
+func getUlimitsFromConfig(config *Config) ([]ulimit, error) {
 	ulimits := make([]ulimit, 0, len(config.RuntimeConfig.DefaultUlimits))
 	for _, u := range config.RuntimeConfig.DefaultUlimits {
 		ul, err := units.ParseUlimit(u)


### PR DESCRIPTION
Hey, this improvement should avoid copying to much data around the stack and will fix the following reported issues:

```
oci/oci.go:428:7: hugeParam: e is heavy (224 bytes); consider passing it by pointer (gocritic)
func (e ExecSyncError) Error() string {
      ^
pkg/storage/runtime.go:380:64: hugeParam: metadata is heavy (157 bytes); consider passing it by pointer (gocritic)
func (r *runtimeService) SetContainerMetadata(idOrName string, metadata RuntimeContainerMetadata) error {
                                                               ^
lib/container_server.go:482:22: hugeParam: spec is heavy (120 bytes); consider passing it by pointer (gocritic)
func configNetNsPath(spec rspec.Spec) (string, error) {
                     ^
pkg/seccomp/seccomp.go:33:28: hugeParam: config is heavy (88 bytes); consider passing it by pointer (gocritic)
func LoadProfileFromStruct(config Seccomp, specgen *generate.Generator) error {
                           ^
pkg/seccomp/seccomp.go:56:19: hugeParam: config is heavy (88 bytes); consider passing it by pointer (gocritic)
func setupSeccomp(config Seccomp, specgen *generate.Generator) error {
                  ^
server/container_create_linux.go:1133:27: hugeParam: config is heavy (832 bytes); consider passing it by pointer (gocritic)
func getDevicesFromConfig(config Config) ([]rspec.LinuxDevice, error) {
                          ^
server/utils.go:261:27: hugeParam: config is heavy (832 bytes); consider passing it by pointer (gocritic)
func getUlimitsFromConfig(config Config) ([]ulimit, error) {
                          ^
server/config_test.go:26:44: hugeParam: c is heavy (832 bytes); consider passing it by pointer (gocritic)
func assertAllFieldsEquality(t *testing.T, c Config) {
```