### PR TITLE
Log oom_handling_score failure to debug

### DIFF
--- a/conmon/conmon.c
+++ b/conmon/conmon.c
@@ -955,19 +955,6 @@ int main(int argc, char *argv[])
 	int fds[2];
 	int oom_score_fd = -1;
 
-	oom_score_fd = open("/proc/self/oom_score_adj", O_WRONLY);
-	if (oom_score_fd < 0) {
-		g_print("failed to open /proc/self/oom_score_adj: %s\n", strerror(errno));
-	} else {
-		if (write(oom_score_fd, OOM_SCORE, strlen(OOM_SCORE)) < 0) {
-			g_print("failed to write to /proc/self/oom_score_adj: %s\n", strerror(errno));
-		}
-		close(oom_score_fd);
-	}
-
-
-	main_loop = g_main_loop_new(NULL, FALSE);
-
 	/* Command line parameters */
 	context = g_option_context_new("- conmon utility");
 	g_option_context_add_main_entries(context, opt_entries, "conmon");
@@ -986,6 +973,19 @@ int main(int argc, char *argv[])
 	}
 
 	set_conmon_logs(opt_log_level, opt_cid, opt_syslog);
+
+	oom_score_fd = open("/proc/self/oom_score_adj", O_WRONLY);
+	if (oom_score_fd < 0) {
+		ndebugf("failed to open /proc/self/oom_score_adj: %s\n", strerror(errno));
+	} else {
+		if (write(oom_score_fd, OOM_SCORE, strlen(OOM_SCORE)) < 0) {
+			ndebugf("failed to write to /proc/self/oom_score_adj: %s\n", strerror(errno));
+		}
+		close(oom_score_fd);
+	}
+
+
+	main_loop = g_main_loop_new(NULL, FALSE);
 
 	if (opt_restore_path && opt_exec)
 		nexit("Cannot use 'exec' and 'restore' at the same time.");


### PR DESCRIPTION
In testing the newest conmon with podman, the g_print for oom_handling_score failing to open the fd printed every time podman was run as rootless. Fix this by changing it to ndebugf, so a normal user won't encounter the failure.

Also move the handling higher so the log level is set already

Signed-off-by: Peter Hunt <pehunt@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/kubernetes-sigs/cri-o/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
