### PR TITLE
[1.10] Pick up correct gid

### DIFF
--- a/server/container_create.go
+++ b/server/container_create.go
@@ -468,7 +468,11 @@ func setupContainerUser(specgen *generate.Generator, rootfs string, sc *pb.Linux
 		if sc.GetRunAsUser() == nil && sc.GetRunAsUsername() == "" && sc.GetRunAsGroup() != nil {
 			return fmt.Errorf("RunAsGroup should be specified only with RunAsUser or RunAsUsername")
 		}
-		groupstr := strconv.FormatInt(sc.GetRunAsGroup().GetValue(), 10)
+
+		var groupstr string
+		if sc.GetRunAsGroup() != nil {
+			groupstr = strconv.FormatInt(sc.GetRunAsGroup().GetValue(), 10)
+		}
 		if groupstr != "" {
 			containerUser = containerUser + ":" + groupstr
 		}

--- a/test/ctr.bats
+++ b/test/ctr.bats
@@ -1106,3 +1106,66 @@ function teardown() {
 	cleanup_pods
 	stop_crio
 }
+
+@test "ctr with run_as_username set to redis should get 101 as the gid for redis:alpine" {
+	start_crio
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	newconfig=$(cat "$TESTDATA"/container_redis.json | python -c 'import json,sys;obj=json.load(sys.stdin);obj["linux"]["security_context"]["run_as_username"] = "redis"; json.dump(obj, sys.stdout)')
+	echo "$newconfig" > "$TESTDIR"/container_user.json
+
+	run crictl create "$pod_id" "$TESTDIR"/container_user.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" id
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "uid=100(redis) gid=101(redis) groups=101(redis)" ]]
+
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}
+
+@test "ctr with run_as_user set to 100 should get 101 as the gid for redis:alpine" {
+	start_crio
+	run crictl runp "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	pod_id="$output"
+
+	run crictl create "$pod_id" "$TESTDATA"/container_redis_user.json "$TESTDATA"/sandbox_config.json
+	echo "$output"
+	[ "$status" -eq 0 ]
+	ctr_id="$output"
+	run crictl start "$ctr_id"
+	[ "$status" -eq 0 ]
+
+	run crictl exec --sync "$ctr_id" id
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "uid=100(redis) gid=101(redis) groups=101(redis)" ]]
+
+	run crictl stopp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	run crictl rmp "$pod_id"
+	echo "$output"
+	[ "$status" -eq 0 ]
+	cleanup_ctrs
+	cleanup_pods
+	stop_crio
+}

--- a/test/testdata/container_redis_user.json
+++ b/test/testdata/container_redis_user.json
@@ -1,0 +1,71 @@
+{
+	"metadata": {
+		"name": "podsandbox1-redis"
+	},
+	"image": {
+		"image": "redis:alpine"
+	},
+	"command": [
+        "sleep",
+        "1000"
+	],
+	"args": [],
+	"working_dir": "/data",
+	"envs": [
+		{
+			"key": "PATH",
+			"value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+		},
+		{
+			"key": "TERM",
+			"value": "xterm"
+		},
+		{
+			"key": "REDIS_VERSION",
+			"value": "3.2.3"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_URL",
+			"value": "http://download.redis.io/releases/redis-3.2.3.tar.gz"
+		},
+		{
+			"key": "REDIS_DOWNLOAD_SHA1",
+			"value": "92d6d93ef2efc91e595c8bf578bf72baff397507"
+		}
+	],
+	"labels": {
+		"tier": "backend"
+	},
+	"annotations": {
+		"pod": "podsandbox1"
+	},
+	"readonly_rootfs": false,
+	"log_path": "",
+	"stdin": false,
+	"stdin_once": false,
+	"tty": false,
+	"linux": {
+		"resources": {
+			"memory_limit_in_bytes": 209715200,
+			"cpu_period": 10000,
+			"cpu_quota": 20000,
+			"cpu_shares": 512,
+			"oom_score_adj": 30,
+			"cpuset_cpus": "0",
+			"cpuset_mems": "0"
+		},
+		"security_context": {
+			"run_as_user": {
+				"value": 100
+			},
+			"namespace_options": {
+				"pid": 1
+			},
+			"capabilities": {
+				"add_capabilities": [
+					"sys_admin"
+				]
+			}
+		}
+	}
+}


### PR DESCRIPTION
When setting the gid, we were not checking if RunAsGroup
from k8s was nil or not. We were simply converting that
to an int and nil was becoming 0. Hence all the containers
were being run with gid root regardless of their uid.
Adding that check here fixes it and we get the correct gid.

backport https://github.com/kubernetes-sigs/cri-o/pull/2173

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
