### PR TITLE
Remove timeout flag from kubernetes.yml

### DIFF
--- a/contrib/test/integration/build/kubernetes.yml
+++ b/contrib/test/integration/build/kubernetes.yml
@@ -42,7 +42,7 @@
       export FEATURE_GATES="AllAlpha=false,RunAsGroup=true"
       export CONTAINER_RUNTIME=remote
       export CGROUP_DRIVER=systemd
-      export CONTAINER_RUNTIME_ENDPOINT='{{ crio_socket }} --runtime-request-timeout=5m'
+      export CONTAINER_RUNTIME_ENDPOINT='{{ crio_socket }}'
       export ALLOW_SECURITY_CONTEXT=","
       export ALLOW_PRIVILEGED=1
       export DNS_SERVER_IP={{ ansible_default_ipv4.address }}


### PR DESCRIPTION
Upstream changed the way it accepts flags, and the timeout
flag is causing issues when determining the runtime socket.
Removing for now to unblock cri-o PRs.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>
